### PR TITLE
feat: 디바이스 헤더 추출 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter:1.17.6")
     testImplementation("org.testcontainers:mysql:1.17.6")
     testImplementation("io.rest-assured:rest-assured")
+    testImplementation("io.mockk:mockk:1.12.4")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/nexters/linkllet/article/domain/Articles.kt
+++ b/src/main/kotlin/nexters/linkllet/article/domain/Articles.kt
@@ -11,7 +11,7 @@ class Articles {
     private val articles: MutableList<Article> = mutableListOf()
 
     companion object {
-        private val MAX_FOLDER_SIZE = 50
+        private const val MAX_FOLDER_SIZE = 50
     }
 
     fun add(article: Article) {

--- a/src/main/kotlin/nexters/linkllet/common/config/WebMvcConfig.kt
+++ b/src/main/kotlin/nexters/linkllet/common/config/WebMvcConfig.kt
@@ -1,0 +1,16 @@
+package nexters.linkllet.common.config
+
+import nexters.linkllet.common.support.DeviceUserResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(
+        val deviceUserResolver: DeviceUserResolver,
+) : WebMvcConfigurer {
+
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
+        resolvers.add(deviceUserResolver)
+    }
+}

--- a/src/main/kotlin/nexters/linkllet/common/support/AccessDeviceId.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/AccessDeviceId.kt
@@ -1,0 +1,5 @@
+package nexters.linkllet.common.support
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class AccessDeviceId

--- a/src/main/kotlin/nexters/linkllet/common/support/DeviceHeaderExtractor.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/DeviceHeaderExtractor.kt
@@ -1,0 +1,15 @@
+package nexters.linkllet.common.support
+
+import org.springframework.web.context.request.NativeWebRequest
+
+private const val DEVICE_ID_HEADER = "Device-Id"
+
+class DeviceHeaderExtractor {
+
+    companion object {
+        fun extractDeviceId(request: NativeWebRequest): String {
+            return request.getHeader(DEVICE_ID_HEADER)
+                    ?: throw IllegalArgumentException("디바이스 ID가 존재하지 않습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/nexters/linkllet/common/support/DeviceUserResolver.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/DeviceUserResolver.kt
@@ -1,0 +1,25 @@
+package nexters.linkllet.common.support
+
+import org.springframework.core.MethodParameter
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class DeviceUserResolver : HandlerMethodArgumentResolver {
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return parameter.hasParameterAnnotation(AccessDeviceId::class.java)
+    }
+
+    override fun resolveArgument(
+            parameter: MethodParameter,
+            mavContainer: ModelAndViewContainer?,
+            webRequest: NativeWebRequest,
+            binderFactory: WebDataBinderFactory?,
+    ): String {
+        return DeviceHeaderExtractor.extractDeviceId(webRequest)
+    }
+}

--- a/src/main/kotlin/nexters/linkllet/config/WebMvcConfiguration.kt
+++ b/src/main/kotlin/nexters/linkllet/config/WebMvcConfiguration.kt
@@ -1,16 +1,23 @@
-package nexters.linkllet.common.config
+package nexters.linkllet.config
 
 import nexters.linkllet.common.support.DeviceUserResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class WebMvcConfig(
+class WebMvcConfiguration(
         val deviceUserResolver: DeviceUserResolver,
 ) : WebMvcConfigurer {
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver>) {
         resolvers.add(deviceUserResolver)
+    }
+
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("*")
     }
 }

--- a/src/main/kotlin/nexters/linkllet/config/WebMvcConfiguration.kt
+++ b/src/main/kotlin/nexters/linkllet/config/WebMvcConfiguration.kt
@@ -18,6 +18,6 @@ class WebMvcConfiguration(
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
                 .allowedOrigins("*")
-                .allowedMethods("*")
+                .allowedMethods("GET", "POST", "DELETE", "PUT", "OPTIONS")
     }
 }

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderCommandApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderCommandApi.kt
@@ -1,5 +1,6 @@
 package nexters.linkllet.folder.presentation
 
+import nexters.linkllet.common.support.AccessDeviceId
 import nexters.linkllet.folder.dto.ArticleCreateRequest
 import nexters.linkllet.folder.dto.FolderCreateRequest
 import nexters.linkllet.folder.service.FolderService
@@ -9,17 +10,13 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/v1/folders")
 class FolderCommandApi(
-    private val folderService: FolderService,
+        private val folderService: FolderService,
 ) {
-
-    companion object {
-        private const val DEVICE_ID_HEADER_KEY: String = "Device-Id"
-    }
 
     @PostMapping
     fun createFolder(
-        @RequestBody request: FolderCreateRequest,
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @RequestBody request: FolderCreateRequest,
+            @AccessDeviceId deviceId: String,
     ): ResponseEntity<Unit> {
         folderService.createFolder(request.name, deviceId)
         return ResponseEntity.ok().build()
@@ -27,8 +24,8 @@ class FolderCommandApi(
 
     @DeleteMapping("/{id}")
     fun deleteFolder(
-        @PathVariable id: Long,
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @PathVariable id: Long,
+            @AccessDeviceId deviceId: String,
     ): ResponseEntity<Unit> {
         folderService.deleteFolder(id, deviceId)
         return ResponseEntity.noContent().build()
@@ -36,9 +33,9 @@ class FolderCommandApi(
 
     @PostMapping("/{id}/articles")
     fun createArticle(
-        @PathVariable id: Long,
-        @RequestBody request: ArticleCreateRequest,
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @PathVariable id: Long,
+            @RequestBody request: ArticleCreateRequest,
+            @AccessDeviceId deviceId: String,
     ): ResponseEntity<Unit> {
         folderService.addArticleAtFolder(id, request.name, request.url, deviceId)
         return ResponseEntity.ok().build()
@@ -46,9 +43,9 @@ class FolderCommandApi(
 
     @DeleteMapping("/{id}/articles/{articleId}")
     fun createArticle(
-        @PathVariable id: Long,
-        @PathVariable articleId: Long,
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @PathVariable id: Long,
+            @PathVariable articleId: Long,
+            @AccessDeviceId deviceId: String,
     ): ResponseEntity<Unit> {
         folderService.deleteArticleAtFolder(id, articleId, deviceId)
         return ResponseEntity.noContent().build()

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
@@ -1,5 +1,6 @@
 package nexters.linkllet.folder.presentation
 
+import nexters.linkllet.common.support.AccessDeviceId
 import nexters.linkllet.folder.dto.ArticleLookupListResponse
 import nexters.linkllet.folder.dto.FolderLookupListResponse
 import nexters.linkllet.folder.service.FolderService
@@ -9,16 +10,12 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/api/v1/folders")
 class FolderQueryApi(
-    private val folderService: FolderService,
+        private val folderService: FolderService,
 ) {
-
-    companion object {
-        private const val DEVICE_ID_HEADER_KEY: String = "Device-Id"
-    }
 
     @GetMapping
     fun lookUpFolderList(
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @AccessDeviceId deviceId: String,
     ): ResponseEntity<FolderLookupListResponse> {
         val lookupDtoList = folderService.lookupFolderList(deviceId)
         return ResponseEntity.ok().body(lookupDtoList)
@@ -26,8 +23,8 @@ class FolderQueryApi(
 
     @GetMapping("/{id}/articles")
     fun lookUpArticleList(
-        @PathVariable id: Long,
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @PathVariable id: Long,
+            @AccessDeviceId deviceId: String,
     ): ResponseEntity<ArticleLookupListResponse> {
         val lookupDtoList = folderService.lookupArticleList(id, deviceId)
         return ResponseEntity.ok().body(lookupDtoList)

--- a/src/test/kotlin/nexters/linkllet/common/support/DeviceHeaderExtractorTest.kt
+++ b/src/test/kotlin/nexters/linkllet/common/support/DeviceHeaderExtractorTest.kt
@@ -3,7 +3,6 @@ package nexters.linkllet.common.support
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows

--- a/src/test/kotlin/nexters/linkllet/common/support/DeviceHeaderExtractorTest.kt
+++ b/src/test/kotlin/nexters/linkllet/common/support/DeviceHeaderExtractorTest.kt
@@ -1,0 +1,40 @@
+package nexters.linkllet.common.support
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.web.context.request.NativeWebRequest
+
+class DeviceHeaderExtractorTest {
+
+    @Test
+    @DisplayName("디바이스 ID를 추출한다")
+    fun extractValidDeviceId() {
+        // given
+        val request = mockk<NativeWebRequest>()
+        val expected = "kth990303"
+        every { request.getHeader("Device-Id") } returns expected
+
+        // when
+        val actual = DeviceHeaderExtractor.extractDeviceId(request)
+
+        // then
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    @DisplayName("디바이스 ID가 존재하지 않으면 예외를 반환한다")
+    fun extractInvalidDeviceId() {
+        // given
+        val request = mockk<NativeWebRequest>()
+        every { request.getHeader("Device-Id") } returns null
+
+        // when
+        // then
+        assertThrows<IllegalArgumentException> { DeviceHeaderExtractor.extractDeviceId(request) }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,6 +9,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+    open-in-view: false
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
close #5 

## 구현사항
- `HandlerMethodArgumentResolver`를 커스텀한 `DeviceUserResolver`에서 `Device-Id` 헤더를 추출하도록 기능 구현.
- 컨트롤러에서 `@RequestHeader`대신 `@AccessDeviceId` 만으로 헤더 추출할 수 있도록 구현 및 중복로직 제거
- `WebMvcConfiguration` 에서 리졸버 등록과 함께 CORS 이슈 해결

## 리뷰받고 싶은 사항
- 패키지 위치가 적절한지 (`config` vs `support`)
- 헤더 키가 `Device-Id`가 적절할지, 대문자를 포함할지 소문자만으로 이루어질지
- 그 외 더 좋은 변수명 있으면 부담없이 리뷰해주세요