### PR TITLE
feat: Swagger API 자동 문서화 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
     runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
+    // Swagger
+    implementation ("org.springdoc:springdoc-openapi-ui:1.6.14")
+
     // Test Container
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testImplementation("org.testcontainers:testcontainers:1.17.6")

--- a/src/main/kotlin/nexters/linkllet/common/support/AccessDeviceId.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/AccessDeviceId.kt
@@ -1,5 +1,8 @@
 package nexters.linkllet.common.support
 
+import io.swagger.v3.oas.annotations.Hidden
+
+@Hidden
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class AccessDeviceId

--- a/src/main/kotlin/nexters/linkllet/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/nexters/linkllet/config/SwaggerConfiguration.kt
@@ -1,0 +1,33 @@
+package nexters.linkllet.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Contact
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+private const val DEVICE_ID_HEADER = "Device-Id"
+
+@Configuration
+class SwaggerConfiguration {
+
+    @Bean
+    fun api(): OpenAPI {
+        val info = Info()
+                .title("Linkllet 백엔드 API 명세")
+                .description("springdoc을 이용한 Swagger API 문서입니다.")
+                .version("1.0")
+                .contact(Contact().name("springdoc 공식문서").url("https://springdoc.org/"))
+
+        val deviceHeader = SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .`in`(SecurityScheme.In.HEADER)
+                .name(DEVICE_ID_HEADER)
+
+        return OpenAPI()
+                .components(Components().addSecuritySchemes(DEVICE_ID_HEADER, deviceHeader))
+                .info(info)
+    }
+}

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderCommandApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderCommandApi.kt
@@ -18,7 +18,7 @@ class FolderCommandApi(
 ) {
 
     @Operation(summary = "폴더 생성")
-    @SecurityRequirement(name = "DeviceId")
+    @SecurityRequirement(name = "Device-Id")
     @PostMapping
     fun createFolder(
             @RequestBody request: FolderCreateRequest,
@@ -29,7 +29,7 @@ class FolderCommandApi(
     }
 
     @Operation(summary = "폴더 삭제")
-    @SecurityRequirement(name = "DeviceId")
+    @SecurityRequirement(name = "Device-Id")
     @DeleteMapping("/{id}")
     fun deleteFolder(
             @PathVariable id: Long,
@@ -40,7 +40,7 @@ class FolderCommandApi(
     }
 
     @Operation(summary = "링크 생성")
-    @SecurityRequirement(name = "DeviceId")
+    @SecurityRequirement(name = "Device-Id")
     @PostMapping("/{id}/articles")
     fun createArticle(
             @PathVariable id: Long,
@@ -52,7 +52,7 @@ class FolderCommandApi(
     }
 
     @Operation(summary = "링크 삭제")
-    @SecurityRequirement(name = "DeviceId")
+    @SecurityRequirement(name = "Device-Id")
     @DeleteMapping("/{id}/articles/{articleId}")
     fun createArticle(
             @PathVariable id: Long,

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderCommandApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderCommandApi.kt
@@ -1,54 +1,66 @@
 package nexters.linkllet.folder.presentation
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import nexters.linkllet.folder.dto.ArticleCreateRequest
 import nexters.linkllet.folder.dto.FolderCreateRequest
 import nexters.linkllet.folder.service.FolderService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
+@Tag(name = "Folders-Command", description = "폴더 작업")
 @RestController
 @RequestMapping("/api/v1/folders")
 class FolderCommandApi(
-    private val folderService: FolderService,
+        private val folderService: FolderService,
 ) {
 
     companion object {
         private const val DEVICE_ID_HEADER_KEY: String = "Device-Id"
     }
 
+    @Operation(summary = "폴더 생성")
+    @SecurityRequirement(name = "DeviceId")
     @PostMapping
     fun createFolder(
-        @RequestBody request: FolderCreateRequest,
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @RequestBody request: FolderCreateRequest,
+            @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
     ): ResponseEntity<Unit> {
         folderService.createFolder(request.name, deviceId)
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "폴더 삭제")
+    @SecurityRequirement(name = "DeviceId")
     @DeleteMapping("/{id}")
     fun deleteFolder(
-        @PathVariable id: Long,
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @PathVariable id: Long,
+            @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
     ): ResponseEntity<Unit> {
         folderService.deleteFolder(id, deviceId)
         return ResponseEntity.noContent().build()
     }
 
+    @Operation(summary = "링크 생성")
+    @SecurityRequirement(name = "DeviceId")
     @PostMapping("/{id}/articles")
     fun createArticle(
-        @PathVariable id: Long,
-        @RequestBody request: ArticleCreateRequest,
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @PathVariable id: Long,
+            @RequestBody request: ArticleCreateRequest,
+            @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
     ): ResponseEntity<Unit> {
         folderService.addArticleAtFolder(id, request.name, request.url, deviceId)
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "링크 삭제")
+    @SecurityRequirement(name = "DeviceId")
     @DeleteMapping("/{id}/articles/{articleId}")
-    fun createArticle(
-        @PathVariable id: Long,
-        @PathVariable articleId: Long,
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+    fun deleteArticle(
+            @PathVariable id: Long,
+            @PathVariable articleId: Long,
+            @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
     ): ResponseEntity<Unit> {
         folderService.deleteArticleAtFolder(id, articleId, deviceId)
         return ResponseEntity.noContent().build()

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
@@ -1,33 +1,41 @@
 package nexters.linkllet.folder.presentation
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import nexters.linkllet.folder.dto.ArticleLookupListResponse
 import nexters.linkllet.folder.dto.FolderLookupListResponse
 import nexters.linkllet.folder.service.FolderService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
+@Tag(name = "Folders-Query", description = "폴더 조회")
 @RestController
 @RequestMapping("/api/v1/folders")
 class FolderQueryApi(
-    private val folderService: FolderService,
+        private val folderService: FolderService,
 ) {
 
     companion object {
         private const val DEVICE_ID_HEADER_KEY: String = "Device-Id"
     }
 
+    @Operation(summary = "폴더 목록 조회")
+    @SecurityRequirement(name = "DeviceId")
     @GetMapping
     fun lookUpFolderList(
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
     ): ResponseEntity<FolderLookupListResponse> {
         val lookupDtoList = folderService.lookupFolderList(deviceId)
         return ResponseEntity.ok().body(lookupDtoList)
     }
 
+    @Operation(summary = "기사 목록 조회")
+    @SecurityRequirement(name = "DeviceId")
     @GetMapping("/{id}/articles")
     fun lookUpArticleList(
-        @PathVariable id: Long,
-        @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
+            @PathVariable id: Long,
+            @RequestHeader(DEVICE_ID_HEADER_KEY) deviceId: String,
     ): ResponseEntity<ArticleLookupListResponse> {
         val lookupDtoList = folderService.lookupArticleList(id, deviceId)
         return ResponseEntity.ok().body(lookupDtoList)

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
@@ -18,7 +18,7 @@ class FolderQueryApi(
 ) {
 
     @Operation(summary = "폴더 목록 조회")
-    @SecurityRequirement(name = "DeviceId")
+    @SecurityRequirement(name = "Device-Id")
     @GetMapping
     fun lookUpFolderList(
             @AccessDeviceId deviceId: String,
@@ -28,7 +28,7 @@ class FolderQueryApi(
     }
 
     @Operation(summary = "기사 목록 조회")
-    @SecurityRequirement(name = "DeviceId")
+    @SecurityRequirement(name = "Device-Id")
     @GetMapping("/{id}/articles")
     fun lookUpArticleList(
             @PathVariable id: Long,

--- a/src/main/kotlin/nexters/linkllet/member/presentation/MemberCommandApi.kt
+++ b/src/main/kotlin/nexters/linkllet/member/presentation/MemberCommandApi.kt
@@ -1,5 +1,7 @@
 package nexters.linkllet.member.presentation
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import nexters.linkllet.member.dto.MemberSignUpRequest
 import nexters.linkllet.member.service.MemberService
 import org.springframework.http.ResponseEntity
@@ -8,12 +10,14 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Members", description = "회원")
 @RestController
 @RequestMapping("/api/v1")
 class MemberCommandApi(
     private val memberService: MemberService,
 ) {
 
+    @Operation(summary = "회원가입")
     @PostMapping("/members")
     fun signUp(
         @RequestBody request: MemberSignUpRequest,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,13 @@ spring:
     password: ${DB_PASSWORD}
     username: ${DB_USER}
     url: ${DB_URL}
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    path: /swagger-ui.html
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha  # alpha: 알파벳 순 / method: http method 순 정렬
+    tags-sorter: alpha


### PR DESCRIPTION
close #6 

## 구현사항
- Swagger 세팅 추가 (ver. 1.6.14  [MvnRepository](https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui))
<img width="934" alt="image" src="https://github.com/Nexters/Linkllet-Server/assets/57135043/ed53ea35-c9e9-4980-9d35-3dcf0c128beb">

- springfox 라이브러리와 springdoc 라이브러리 중에 후자를 선택했습니다.
전자의 경우 사실상 업데이트가 한참동안 되지 않는 라이브러리이며 기능 또한 그만큼 적다고 판단했기 때문입니다.


## 주의사항
- #13 이 먼저 Merge 되어야 추가적인 작업을 할 수 있습니다.  (현재는 `@RequestHeader` 로 인해 매 API 마다 device-id 를 번거롭게 입력해주어야 함.)

## 테스트 방법
1. 애플리케이션 실행
2. `http://localhost:8080/swagger-ui/index.html` 접속
3. Swagger를 이용하여 수행 (단, Authorize를 이용한다 하더라도 위에서 언급한 `@RequestHeader` 때문에 매 API 마다 device-id 를 넣어주어야 하는 번거로움 존재. 추후 수정 예정)