### PR TITLE
fix: validate duplicated device id 

### DIFF
--- a/src/main/kotlin/nexters/linkllet/common/exception/dto/ErrorDtos.kt
+++ b/src/main/kotlin/nexters/linkllet/common/exception/dto/ErrorDtos.kt
@@ -20,3 +20,5 @@ class ForbiddenException(message: String = "권한이 존재하지 않습니다.
 class NotFoundException(message: String = "존재하지 않는 요청입니다.")
     : LinklletException(message, HttpStatus.NOT_FOUND.value())
 
+class ConflictException(message: String = "이미 등록된 디바이스 입니다.")
+    : LinklletException(message, HttpStatus.CONFLICT.value())

--- a/src/main/kotlin/nexters/linkllet/member/service/MemberService.kt
+++ b/src/main/kotlin/nexters/linkllet/member/service/MemberService.kt
@@ -1,5 +1,6 @@
 package nexters.linkllet.member.service
 
+import nexters.linkllet.common.exception.dto.ConflictException
 import nexters.linkllet.folder.domain.Folder
 import nexters.linkllet.folder.domain.FolderRepository
 import nexters.linkllet.folder.domain.FolderType
@@ -18,6 +19,9 @@ class MemberService(
 ) {
 
     fun signUp(deviceId: String) {
+        memberRepository.findByDeviceId(deviceId)
+            ?: throw ConflictException()
+
         val newMember = memberRepository.save(Member(deviceId))
         folderRepository.save(Folder(DEFAULT_FOLDER_NAME, newMember.getId, FolderType.DEFAULT))
     }

--- a/src/main/kotlin/nexters/linkllet/member/service/MemberService.kt
+++ b/src/main/kotlin/nexters/linkllet/member/service/MemberService.kt
@@ -20,7 +20,7 @@ class MemberService(
 
     fun signUp(deviceId: String) {
         memberRepository.findByDeviceId(deviceId)
-            ?: throw ConflictException()
+            ?.let { throw ConflictException() }
 
         val newMember = memberRepository.save(Member(deviceId))
         folderRepository.save(Folder(DEFAULT_FOLDER_NAME, newMember.getId, FolderType.DEFAULT))

--- a/src/test/kotlin/nexters/linkllet/acceptance/MemberAcceptanceTest.kt
+++ b/src/test/kotlin/nexters/linkllet/acceptance/MemberAcceptanceTest.kt
@@ -20,4 +20,21 @@ class MemberAcceptanceTest : AcceptanceTest() {
 
         응답_확인(회원_가입_응답, HttpStatus.OK)
     }
+
+    /**
+     * given: 회원 가입된 사용자 shine이 존재한다.
+     * when: 동일한 device id인 shine으로 가입을 요청한다
+     * then: Conflict 상태코드를 응답한다
+     */
+    @Test
+    fun `중복 회원 가입`() {
+        // given
+        회원_가입_요청(MemberSignUpRequest("shine"))
+
+        // when
+        val 회원_가입_응답 = 회원_가입_요청(MemberSignUpRequest("shine"))
+
+        // then
+        응답_확인(회원_가입_응답, HttpStatus.CONFLICT)
+    }
 }


### PR DESCRIPTION
close #15 

## 구현사항
간단하게 사용자가 이미 등록된 기기 ID인지 검증하는 로직을 추가하였습니다.
인수테스트 또한 추가되었습니다.

## 고민사항
상태코드에 대한 고민이 있어 RFC 문서를 살펴보았습니다.
이미 가입된 기기 id가 있다는점은 리소스의 현재 상태와 충돌해서 요청을 처리할 수 없으므로 클라이언트가 요청을 다시 충돌을 수정해서 요청을 다시 보내야 한다 생각하였습니다. 찾아보니 Conflict라는 적합한 상태코드가 있어 사용하였습니다.
```
The request could not be completed due to a conflict with the current state of the target resource. 
This code is used in situations where the user might be able to resolve the conflict and resubmit the request. 
The server SHOULD generate a payload that includes enough information for a user to recognize the source of the conflict.
```
[RFC 7231 링크](http://tools.ietf.org/html/rfc7231#section-6.5.8)