### PR TITLE
feat: MemberService 에서 커스텀 폴더 2개도 추가 생성되도록 구현

### DIFF
--- a/src/main/kotlin/nexters/linkllet/member/service/MemberService.kt
+++ b/src/main/kotlin/nexters/linkllet/member/service/MemberService.kt
@@ -9,7 +9,7 @@ import nexters.linkllet.member.domain.MemberRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
-private const val DEFAULT_FOLDER_NAME = "default"
+private const val DEFAULT_FOLDER_NAME = "Default"
 
 @Transactional
 @Service
@@ -22,7 +22,21 @@ class MemberService(
         memberRepository.findByDeviceId(deviceId)
             ?.let { throw ConflictException() }
 
+        initMember(deviceId)
+    }
+
+    private fun initMember(deviceId: String) {
         val newMember = memberRepository.save(Member(deviceId))
-        folderRepository.save(Folder(DEFAULT_FOLDER_NAME, newMember.getId, FolderType.DEFAULT))
+        createStartFolder(newMember)
+    }
+
+    private fun createStartFolder(newMember: Member) {
+        folderRepository.saveAll(
+            listOf(
+                Folder(DEFAULT_FOLDER_NAME, newMember.getId, FolderType.DEFAULT),
+                Folder("Folder 1", newMember.getId, FolderType.PERSONALIZED),
+                Folder("Folder 2", newMember.getId, FolderType.PERSONALIZED)
+            )
+        )
     }
 }


### PR DESCRIPTION
close #19 

## 구현사항
- 가입시 커스텀 폴더 2개를 추가로 생성하도록 로직 변경

## 리뷰받고 싶은 사항
- 리터럴 부분에 해당되는 "folder_1", "folder_2"가 과연 상수로 뽑아야 할지? 
- 뽑아도 FOLDER_NAME_ONE 이렇게 될거 같아 그냥 리터럴 그대로 두는것이 좋다 생각되는중