### PR TITLE
fix: 링크 길이 제한을 1000자로 변경한다

### DIFF
--- a/src/main/kotlin/nexters/linkllet/article/domain/Article.kt
+++ b/src/main/kotlin/nexters/linkllet/article/domain/Article.kt
@@ -56,6 +56,9 @@ class Article(
         get() = this.createAt
 
     private fun validateArticleLink(link: String) {
+        if (link.isBlank()) {
+            throw BadRequestException("링크는 공백일 수 없습니다.")
+        }
         if (link.length > LINK_CONTENT_LENGTH_LIMIT) {
             throw BadRequestException("1000자를 초과하는 링크는 저장할 수 없습니다.")
         }

--- a/src/main/kotlin/nexters/linkllet/article/domain/Article.kt
+++ b/src/main/kotlin/nexters/linkllet/article/domain/Article.kt
@@ -6,6 +6,7 @@ import nexters.linkllet.folder.domain.Folder
 import java.time.LocalDateTime
 import javax.persistence.*
 
+private const val LINK_CONTENT_LENGTH_LIMIT = 1000
 private const val LINK_TITLE_LENGTH_LIMIT = 10
 
 @Entity
@@ -34,6 +35,7 @@ class Article(
     private val link: Link
 
     init {
+        validateArticleLink(_link)
         validateArticleTitle(title)
         this.link = Link(_link)
     }
@@ -52,6 +54,12 @@ class Article(
 
     val getCreatedDateTime: LocalDateTime?
         get() = this.createAt
+
+    private fun validateArticleLink(link: String) {
+        if (link.length > LINK_CONTENT_LENGTH_LIMIT) {
+            throw BadRequestException("1000자를 초과하는 링크는 저장할 수 없습니다.")
+        }
+    }
 
     private fun validateArticleTitle(title: String) {
         if (title.length > LINK_TITLE_LENGTH_LIMIT) {

--- a/src/main/kotlin/nexters/linkllet/article/domain/Link.kt
+++ b/src/main/kotlin/nexters/linkllet/article/domain/Link.kt
@@ -46,7 +46,7 @@ class Link(
         //Example: "/user/heartrate?foo=bar#element1".
         private const val REGEX_RESOURCE_PATH = "(?:/\\S*)?"
 
-        private val REGEX_URL = "^(?:(?:" + REGEX_SCHEME + REGEX_AUTHORATIVE_DECLARATION + ")?" +
+        private const val REGEX_URL = "^(?:(?:" + REGEX_SCHEME + REGEX_AUTHORATIVE_DECLARATION + ")?" +
                 REGEX_USERINFO + REGEX_HOST + REGEX_PORT + REGEX_RESOURCE_PATH + ")$"
 
         private val compiledLinkPattern = Pattern.compile(REGEX_URL)

--- a/src/main/kotlin/nexters/linkllet/article/domain/Link.kt
+++ b/src/main/kotlin/nexters/linkllet/article/domain/Link.kt
@@ -7,7 +7,7 @@ import javax.persistence.Embeddable
 
 @Embeddable
 class Link(
-    @Column(name = "link", nullable = false)
+    @Column(name = "link", length = 1000, nullable = false)
     private val _value: String,
 ) {
 

--- a/src/test/kotlin/nexters/linkllet/domain/article/ArticleTest.kt
+++ b/src/test/kotlin/nexters/linkllet/domain/article/ArticleTest.kt
@@ -34,6 +34,12 @@ class ArticleTest {
     }
 
     @Test
+    @DisplayName("링크 url 공백일 경우 예외를 반환")
+    fun link_blank_validate() {
+        assertThrows<BadRequestException> { Article("", "test_test_t") }
+    }
+
+    @Test
     @DisplayName("링크 url 길이 제한 초과하면 예외를 반환")
     fun link_length_validate() {
         // length: 1001

--- a/src/test/kotlin/nexters/linkllet/domain/article/ArticleTest.kt
+++ b/src/test/kotlin/nexters/linkllet/domain/article/ArticleTest.kt
@@ -34,22 +34,21 @@ class ArticleTest {
     }
 
     @Test
-    @DisplayName("링크 url 길이 제한 테스트")
+    @DisplayName("링크 url 길이 제한 초과하면 예외를 반환")
     fun link_length_validate() {
-        // length: 1067
-        val longLink = "https://www.google.com/search?q=%EC%95%88%EB%8dsfajaslkfjasdkfjkldsafjlsa" +
-                "dkjflksajfldkadsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjalkfjads;jfalksdf" +
-                "jlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjalkfjads;jfalksdf" +
-                "jlasjf;ljlfsadjlafkj;lkdjalkfjads;jfalksdfjlasjf;ljdsfajaslkfjasdkfjkldsafjlsadkjflk" +
-                "sajfldkajlafkj;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflks" +
-                "ajfldkajlafkj;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajf" +
-                "ldkajlafkj;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldk" +
-                "ajlafkj;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajla" +
-                "fkj;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;" +
-                "lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjal" +
-                "kfjads;jfalksdfjlasjf;ljlfsadlfsadkj;lasfkj5%95%ED%95%98%EC%84%B8%EC%9A%94&oq=%EC%95%88%E" +
-                "B%85%95%ED%95%98%EC%84%B8%EC%9A%94&aqs=chrome..69i57j46i433i512l2j0i131i433i512l3j46i131i433" +
-                "i512j69i60.3640j0j7&sourceid=chrome&ie=UTF-8"
+        // length: 1001
+        val longLink = "https://www.google.com/search?q=%EC%95%88%EB%8dsfajaslkfjasdkfjkldsafjlsadkjf" +
+                "lksajfldkadsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjalkfjads;jfalksdfjlasjf;" +
+                "ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjalkfjads;jfalksdfjlasjf;ljlf" +
+                "sadjlafkj;lkdjalkfjads;jfalksdfjlasjf;ljdsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafk" +
+                "j;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;" +
+                "lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkd" +
+                "jalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjalkf" +
+                "jads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjalkfjads" +
+                ";jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjalkfjads;jfal" +
+                "ksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjalkfjads;jfalksdfjl" +
+                "asjf;ljlfsadlfsadkj;lasfkj5%95%ED%95%98%EC%84%B8%EC%969i57j46i433i512l2j0i131i433i512l3j4" +
+                "6i131i433i512j69i60.3640j0j7&sourceid=chrome&ie=UTF-8"
 
         assertThrows<BadRequestException> { Article(longLink, "test") }
     }

--- a/src/test/kotlin/nexters/linkllet/domain/article/ArticleTest.kt
+++ b/src/test/kotlin/nexters/linkllet/domain/article/ArticleTest.kt
@@ -32,4 +32,25 @@ class ArticleTest {
     fun change_long_folder_name() {
         assertThrows<BadRequestException> { Article("https://kth990303.tistory.com/", "test_test_t") }
     }
+
+    @Test
+    @DisplayName("링크 url 길이 제한 테스트")
+    fun link_length_validate() {
+        // length: 1067
+        val longLink = "https://www.google.com/search?q=%EC%95%88%EB%8dsfajaslkfjasdkfjkldsafjlsa" +
+                "dkjflksajfldkadsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjalkfjads;jfalksdf" +
+                "jlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjalkfjads;jfalksdf" +
+                "jlasjf;ljlfsadjlafkj;lkdjalkfjads;jfalksdfjlasjf;ljdsfajaslkfjasdkfjkldsafjlsadkjflk" +
+                "sajfldkajlafkj;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflks" +
+                "ajfldkajlafkj;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajf" +
+                "ldkajlafkj;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldk" +
+                "ajlafkj;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajla" +
+                "fkj;lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;" +
+                "lkdjalkfjads;jfalksdfjlasjf;ljlfsaddsfajaslkfjasdkfjkldsafjlsadkjflksajfldkajlafkj;lkdjal" +
+                "kfjads;jfalksdfjlasjf;ljlfsadlfsadkj;lasfkj5%95%ED%95%98%EC%84%B8%EC%9A%94&oq=%EC%95%88%E" +
+                "B%85%95%ED%95%98%EC%84%B8%EC%9A%94&aqs=chrome..69i57j46i433i512l2j0i131i433i512l3j46i131i433" +
+                "i512j69i60.3640j0j7&sourceid=chrome&ie=UTF-8"
+
+        assertThrows<BadRequestException> { Article(longLink, "test") }
+    }
 }


### PR DESCRIPTION
close #30 

## 구현사항
- 애플리케이션: link column length 1000 명시 및 예외 핸들링 구현, 테스트 코드 추가
- DB: 컬럼 length 변경  #30  참고
  - Swagger로 320자 (기존 255자 제한을 초과하는 링크 길이) 삽입 테스트 완료
