### PR TITLE
feat: create search

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     // Swagger
     implementation ("org.springdoc:springdoc-openapi-ui:1.6.14")
 
+    // DB
+    implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0")
+
     // Test Container
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
     testImplementation("org.testcontainers:testcontainers:1.17.6")

--- a/src/main/kotlin/nexters/linkllet/article/domain/ArticleQueryRepository.kt
+++ b/src/main/kotlin/nexters/linkllet/article/domain/ArticleQueryRepository.kt
@@ -1,6 +1,7 @@
 package nexters.linkllet.article.domain
 
 import com.querydsl.core.BooleanBuilder
+import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import nexters.linkllet.article.domain.QArticle.article
 import nexters.linkllet.folder.dto.ArticleLookupDto
@@ -24,7 +25,10 @@ class ArticleQueryRepository(
                 )
             )
             .from(article)
-            .where(article.memberId.eq(memberId).and(isContainKeyword(splitResult)))
+            .where(
+                article.id.`in`(JPAExpressions.select(article.id).from(article).where(article.memberId.eq(memberId)))
+                    .and(isContainKeyword(splitResult))
+            )
             .orderBy(article.createAt.desc())
             .fetch()
     }

--- a/src/main/kotlin/nexters/linkllet/article/domain/ArticleQueryRepository.kt
+++ b/src/main/kotlin/nexters/linkllet/article/domain/ArticleQueryRepository.kt
@@ -1,0 +1,40 @@
+package nexters.linkllet.article.domain
+
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.jpa.impl.JPAQueryFactory
+import nexters.linkllet.article.domain.QArticle.article
+import nexters.linkllet.folder.dto.ArticleLookupDto
+import nexters.linkllet.folder.dto.QArticleLookupDto
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import org.springframework.stereotype.Repository
+
+@Repository
+class ArticleQueryRepository(
+    private val queryFactory: JPAQueryFactory
+) : QuerydslRepositorySupport(Article::class.java) {
+
+    fun searchAllArticleByKeywords(splitResult: List<String>, memberId: Long): List<ArticleLookupDto> {
+        return queryFactory
+            .select(
+                QArticleLookupDto(
+                    article.id,
+                    article.title,
+                    article.link._value,
+                    article.createAt,
+                )
+            )
+            .from(article)
+            .where(article.memberId.eq(memberId).and(isContainKeyword(splitResult)))
+            .orderBy(article.createAt.desc())
+            .fetch()
+    }
+
+    private fun isContainKeyword(keywords: List<String>): BooleanBuilder? {
+        val booleanBuilder = BooleanBuilder()
+        for (containedName in keywords) {
+            booleanBuilder.or(article.title.contains(containedName))
+        }
+
+        return booleanBuilder
+    }
+}

--- a/src/main/kotlin/nexters/linkllet/folder/dto/ArticleDtos.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/dto/ArticleDtos.kt
@@ -1,6 +1,7 @@
 package nexters.linkllet.folder.dto
 
 import com.fasterxml.jackson.annotation.JsonFormat
+import com.querydsl.core.annotations.QueryProjection
 import nexters.linkllet.article.domain.Article
 import java.time.LocalDateTime
 
@@ -9,7 +10,7 @@ data class ArticleCreateRequest(
     val url: String,
 )
 
-data class ArticleLookupDto(
+data class ArticleLookupDto @QueryProjection constructor(
     val id: Long,
     val name: String,
     val url: String,
@@ -17,7 +18,8 @@ data class ArticleLookupDto(
     val createAt: LocalDateTime,
 ) {
     companion object {
-        fun of(article: Article): ArticleLookupDto = ArticleLookupDto(article.getId, article.getTitle, article.getLink, article.getCreatedDateTime!!)
+        fun of(article: Article): ArticleLookupDto =
+            ArticleLookupDto(article.getId, article.getTitle, article.getLink, article.getCreatedDateTime!!)
     }
 }
 

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
@@ -37,4 +37,15 @@ class FolderQueryApi(
         val lookupDtoList = folderService.lookupArticleList(id, deviceId)
         return ResponseEntity.ok().body(lookupDtoList)
     }
+
+    @Operation(summary = "링크 검색")
+    @SecurityRequirement(name = "Device-Id")
+    @GetMapping("/search")
+    fun searchArticles(
+        @RequestParam content: String,
+        @AccessDeviceId deviceId: String,
+    ): ResponseEntity<ArticleLookupListResponse> {
+        val lookupDtoList = folderService.searchArticlesByContent(content, deviceId)
+        return ResponseEntity.ok().body(lookupDtoList)
+    }
 }

--- a/src/main/kotlin/nexters/linkllet/folder/service/FolderService.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/service/FolderService.kt
@@ -23,7 +23,7 @@ class FolderService(
     private val articleQueryRepository: ArticleQueryRepository,
 ) {
     companion object {
-        private const val SPACE_REGEX = "[\\s+]"
+        private val SPACE_REGEX = "\\s+".toRegex()
     }
 
     fun createFolder(folderName: String, deviceId: String) {

--- a/src/main/kotlin/nexters/linkllet/folder/service/FolderService.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/service/FolderService.kt
@@ -1,6 +1,7 @@
 package nexters.linkllet.folder.service
 
 import nexters.linkllet.article.domain.Article
+import nexters.linkllet.article.domain.ArticleQueryRepository
 import nexters.linkllet.common.exception.dto.BadRequestException
 import nexters.linkllet.folder.domain.Folder
 import nexters.linkllet.folder.domain.FolderRepository
@@ -19,7 +20,11 @@ import org.springframework.transaction.annotation.Transactional
 class FolderService(
     private val folderRepository: FolderRepository,
     private val memberRepository: MemberRepository,
+    private val articleQueryRepository: ArticleQueryRepository,
 ) {
+    companion object {
+        private const val SPACE_REGEX = "[\\s+]"
+    }
 
     fun createFolder(folderName: String, deviceId: String) {
         val findMember = memberRepository.findByDeviceIdOrThrow(deviceId)
@@ -78,5 +83,19 @@ class FolderService(
         val findFolder = folderRepository.findByIdOrThrow(folderId)
 
         findFolder.deleteArticleById(articleId, findMember.getId)
+    }
+
+    @Transactional(readOnly = true)
+    fun searchArticlesByContent(content: String, deviceId: String): ArticleLookupListResponse {
+        val findMember = memberRepository.findByDeviceIdOrThrow(deviceId)
+
+        val searchResults = articleQueryRepository
+            .searchAllArticleByKeywords(splitBySpace(content), findMember.getId)
+
+        return ArticleLookupListResponse(searchResults)
+    }
+
+    private fun splitBySpace(content: String): List<String> {
+        return content.trim().split(SPACE_REGEX)
     }
 }

--- a/src/test/kotlin/nexters/linkllet/acceptance/ArticleAcceptanceTest.kt
+++ b/src/test/kotlin/nexters/linkllet/acceptance/ArticleAcceptanceTest.kt
@@ -168,7 +168,7 @@ class ArticleAcceptanceTest : AcceptanceTest() {
      * then: 검색조건에 부한한 링크 목록이 반환된다.
      */
     @Test
-    fun `링크 검색`() {
+    fun `아티클 검색`() {
         // given
         val deviceId = "shine"
         MemberStep.회원_가입_요청(MemberSignUpRequest(deviceId))

--- a/src/test/kotlin/nexters/linkllet/acceptance/ArticleAcceptanceTest.kt
+++ b/src/test/kotlin/nexters/linkllet/acceptance/ArticleAcceptanceTest.kt
@@ -177,14 +177,13 @@ class ArticleAcceptanceTest : AcceptanceTest() {
 
         val folderId = 폴더_조회_요청(deviceId).jsonPath().getLong("folderList[0].id")
 
-        아티클_생성_요청(deviceId, folderId, "article1")
-        아티클_생성_요청(deviceId, folderId, "article2")
-        아티클_생성_요청(deviceId, folderId, "article3")
-        아티클_생성_요청(deviceId, folderId, "other1")
-        아티클_생성_요청(deviceId, folderId, "other2")
+        아티클_생성_요청(deviceId, folderId, "게일")
+        아티클_생성_요청(deviceId, folderId, "케이가 좋아")
+        아티클_생성_요청(deviceId, folderId, "이케이")
+        아티클_생성_요청(deviceId, folderId, "케 이 요")
 
         // when
-        val 아티클_검색_응답 = 아티클_검색_요청(deviceId, "article")
+        val 아티클_검색_응답 = 아티클_검색_요청(deviceId, "케 이")
 
         // then
         아티클_검색_응답_확인(아티클_검색_응답, 3)

--- a/src/test/kotlin/nexters/linkllet/acceptance/ArticleAcceptanceTest.kt
+++ b/src/test/kotlin/nexters/linkllet/acceptance/ArticleAcceptanceTest.kt
@@ -1,5 +1,7 @@
 package nexters.linkllet.acceptance
 
+import nexters.linkllet.acceptance.ArticleStep.Companion.아티클_검색_요청
+import nexters.linkllet.acceptance.ArticleStep.Companion.아티클_검색_응답_확인
 import nexters.linkllet.acceptance.ArticleStep.Companion.아티클_삭제_요청
 import nexters.linkllet.acceptance.ArticleStep.Companion.아티클_생성_요청
 import nexters.linkllet.acceptance.ArticleStep.Companion.아티클_조회_응답_확인
@@ -10,7 +12,6 @@ import nexters.linkllet.acceptance.FolderStep.Companion.폴더_조회_요청
 import nexters.linkllet.folder.dto.FolderCreateRequest
 import nexters.linkllet.member.dto.MemberSignUpRequest
 import nexters.linkllet.util.AcceptanceTest
-import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
@@ -157,6 +158,35 @@ class ArticleAcceptanceTest : AcceptanceTest() {
         val actual = 아티클_삭제_요청(folderId, firstArticleId)
 
         // then
-        Assertions.assertThat(actual.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value())
+        응답_확인(actual, HttpStatus.FORBIDDEN);
+    }
+
+    /**
+     * given: 회원 가입된 사용자가 존재한다.
+     * And: 특정 사용자가 폴더를 생성하고 링크를 저장한다
+     * when: 해당 사용자가 링크 검색을 요청한다
+     * then: 검색조건에 부한한 링크 목록이 반환된다.
+     */
+    @Test
+    fun `링크 검색`() {
+        // given
+        val deviceId = "shine"
+        MemberStep.회원_가입_요청(MemberSignUpRequest(deviceId))
+
+        폴더_생성_요청(deviceId, FolderCreateRequest("folder"))
+
+        val folderId = 폴더_조회_요청(deviceId).jsonPath().getLong("folderList[0].id")
+
+        아티클_생성_요청(deviceId, folderId, "article1")
+        아티클_생성_요청(deviceId, folderId, "article2")
+        아티클_생성_요청(deviceId, folderId, "article3")
+        아티클_생성_요청(deviceId, folderId, "other1")
+        아티클_생성_요청(deviceId, folderId, "other2")
+
+        // when
+        val 아티클_검색_응답 = 아티클_검색_요청(deviceId, "article")
+
+        // then
+        아티클_검색_응답_확인(아티클_검색_응답, 3)
     }
 }

--- a/src/test/kotlin/nexters/linkllet/acceptance/ArticleStep.kt
+++ b/src/test/kotlin/nexters/linkllet/acceptance/ArticleStep.kt
@@ -48,5 +48,20 @@ class ArticleStep {
                 { Assertions.assertThat(response.jsonPath().getList<Any>("articleList").size).isEqualTo(count) }
             )
         }
+
+        fun 아티클_검색_요청(deviceId: String,content: String): ExtractableResponse<Response> =
+            RestAssured
+                .given().log().all()
+                .header("Device-Id", deviceId)
+                .`when`().get("/api/v1/folders/search?content={content}", content)
+                .then().log().all()
+                .extract()
+
+        fun 아티클_검색_응답_확인(response: ExtractableResponse<Response>, cnt:Int) {
+            assertAll(
+                { Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()) },
+                { Assertions.assertThat(response.jsonPath().getList<Any>("articleList").size).isEqualTo(cnt) }
+            )
+        }
     }
 }


### PR DESCRIPTION
close #35 

## 고민거리
### 고민1 : 인덱스
검색 쿼리 날리면 Extra로 Using filesort가 뜸, order by 날짜 가 들어가서 정렬한번 하게되는데...
Using filesort 제거를 위해 날짜 컬럼을 인덱스 태우면 filesort가 사라지게될것 -> 근데 아티클은 저장,삭제가 빈번해서 인덱스 연산이 나름 많이 수행될수도?? 일단 인덱스 없어도 될거 같아서 안태움
<img width="1393" alt="image" src="https://github.com/Nexters/Linkllet-Server/assets/60593969/c7643cc2-b8c6-41a1-a33d-7755674dd91a">
의견 부탁!

### 고민2 : 디렉토리 위치
Article은 사실 Folder의 subdomain인데, 외부로 페키지가 분리된 상황, 이거 Folder domain안으로 합치는것이 더 적합하지 않을까요?
<img width="339" alt="image" src="https://github.com/Nexters/Linkllet-Server/assets/60593969/734cbb15-5d9f-4e7e-810c-b3f1437cd7a6">

