### PR TITLE
feat: Apple OAuth를 구현한다

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,9 +40,7 @@ dependencies {
     implementation ("org.springdoc:springdoc-openapi-ui:1.6.14")
 
     // JWT
-    compileOnly("io.jsonwebtoken:jjwt-api:0.11.2")
-    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
-    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
+    implementation("io.jsonwebtoken:jjwt:0.9.1")
 
     // Feign
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,9 @@ dependencies {
     implementation ("org.springdoc:springdoc-openapi-ui:1.6.14")
 
     // JWT
-    implementation("io.jsonwebtoken:jjwt:0.9.1")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.2")
+    implementation("io.jsonwebtoken:jjwt-impl:0.11.2")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.11.2")
 
     // Feign
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,10 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
 
+    // Feign
+    implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2021.0.5"))
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+
     // DB
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0")
 

--- a/src/main/kotlin/nexters/linkllet/common/exception/CommonExceptionHandler.kt
+++ b/src/main/kotlin/nexters/linkllet/common/exception/CommonExceptionHandler.kt
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest
 class CommonExceptionHandler {
 
     companion object {
-        private val log: Logger = LoggerFactory.getLogger(this.javaClass)!!
+        private val log: Logger = LoggerFactory.getLogger(this::class.java)!!
     }
 
     @ExceptionHandler

--- a/src/main/kotlin/nexters/linkllet/common/support/JwtProvider.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/JwtProvider.kt
@@ -27,11 +27,17 @@ class JwtProvider(
 
     fun getPayload(token: String): String {
         try {
-            return Jwts.parser().parseClaimsJws(token).body.subject
+            return extractPayload(token)
         } catch (e: JwtException) {
             throw UnauthorizedException()
         } catch (e: IllegalArgumentException) {
             throw UnauthorizedException()
         }
     }
+
+    private fun extractPayload(token: String) = Jwts.parser()
+            .setSigningKey(jwtConfigProperties.secretKey)
+            .parseClaimsJws(token)
+            .body
+            .subject
 }

--- a/src/main/kotlin/nexters/linkllet/common/support/apple/AppleClaimsValidator.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/apple/AppleClaimsValidator.kt
@@ -1,0 +1,41 @@
+package nexters.linkllet.common.support.apple
+
+import io.jsonwebtoken.Claims
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
+import nexters.linkllet.config.AppleOAuthConfigProperties
+import org.springframework.stereotype.Component
+
+@Component
+class AppleClaimsValidator(
+        private val appleOAuthConfigProperties: AppleOAuthConfigProperties,
+) {
+
+    fun isValid(claims: Claims): Boolean {
+        return claims.issuer.contains(appleOAuthConfigProperties.iss) &&
+                claims.audience == appleOAuthConfigProperties.clientId &&
+                claims.get(NONCE_KEY, String::class.java) == encrypt(appleOAuthConfigProperties.nonce);
+    }
+
+    companion object {
+        fun encrypt(nonce: String): String {
+            return try {
+                val sha256 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM)
+                val digest = sha256.digest(nonce.toByteArray(StandardCharsets.UTF_8))
+                val hexString = StringBuilder()
+                for (b in digest) {
+                    hexString.append(String.format(HEX_STRING_FORMAT, b))
+                }
+                hexString.toString()
+            } catch (e: NoSuchAlgorithmException) {
+                throw IllegalArgumentException("Apple OAuth 통신 암호화 과정 중 문제가 발생했습니다.")
+            }
+        }
+
+        private const val MESSAGE_DIGEST_ALGORITHM = "SHA-256"
+        private const val HEX_STRING_FORMAT = "%02x"
+
+        private const val NONCE_KEY = "nonce"
+    }
+}

--- a/src/main/kotlin/nexters/linkllet/common/support/apple/AppleClient.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/apple/AppleClient.kt
@@ -1,0 +1,11 @@
+package nexters.linkllet.common.support.apple
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+
+@FeignClient(name = "apple-public-key-client", url = "https://appleid.apple.com/auth")
+interface AppleClient {
+
+    @GetMapping("/keys")
+    fun getApplePublicKeys(): ApplePublicKeys
+}

--- a/src/main/kotlin/nexters/linkllet/common/support/apple/AppleJwtParser.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/apple/AppleJwtParser.kt
@@ -1,0 +1,63 @@
+package nexters.linkllet.common.support.apple
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.MalformedJwtException
+import io.jsonwebtoken.SignatureException
+import io.jsonwebtoken.UnsupportedJwtException
+import java.security.PublicKey
+import nexters.linkllet.common.exception.dto.UnauthorizedException
+import org.springframework.stereotype.Component
+import org.springframework.util.Base64Utils
+
+@Component
+class AppleJwtParser {
+
+    fun parseHeaders(idToken: String): Map<String, String> {
+        try {
+            val encodedHeader = idToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX]
+            /*
+            * encodedHeader.replace(".", "") 이유는 아래 에러 발생 때문
+            * illegal base64 character 2e
+            * (ASCII 2e == 46 : ".")
+            * Java 에서는 "." 안없애도 에러가 안뜨지만 kotlin 은 에러 발생. 왜 발생하는 것인지 추후 확인 필요
+            */
+            val decodedHeader =
+                    String(Base64Utils.decodeFromUrlSafeString(encodedHeader.replace(".", "")))
+            return OBJECT_MAPPER.readValue(decodedHeader)
+        } catch (e: JsonProcessingException) {
+            throw UnauthorizedException("Apple OAuth Identity Token 형식이 올바르지 않습니다.")
+        } catch (e: ArrayIndexOutOfBoundsException) {
+            throw UnauthorizedException("Apple OAuth Identity Token 형식이 올바르지 않습니다.")
+        }
+    }
+
+    fun parsePublicKeyAndGetClaims(idToken: String, publicKey: PublicKey): Claims {
+        return try {
+            Jwts.parser()
+                    .setSigningKey(publicKey)
+                    .parseClaimsJws(idToken)
+                    .body
+        } catch (e: ExpiredJwtException) {
+            throw UnauthorizedException("Apple OAuth 로그인 중 Identity Token 유효기간이 만료됐습니다.")
+        } catch (e: UnsupportedJwtException) {
+            throw UnauthorizedException("Apple OAuth Identity Token 값이 올바르지 않습니다.")
+        } catch (e: MalformedJwtException) {
+            throw UnauthorizedException("Apple OAuth Identity Token 값이 올바르지 않습니다.")
+        } catch (e: SignatureException) {
+            throw UnauthorizedException("Apple OAuth Identity Token 값이 올바르지 않습니다.")
+        } catch (e: IllegalArgumentException) {
+            throw UnauthorizedException("Apple OAuth Identity Token 값이 올바르지 않습니다.")
+        }
+    }
+
+    companion object {
+        private const val IDENTITY_TOKEN_VALUE_DELIMITER = "\\."
+        private const val HEADER_INDEX = 0
+        private val OBJECT_MAPPER: ObjectMapper = ObjectMapper()
+    }
+}

--- a/src/main/kotlin/nexters/linkllet/common/support/apple/AppleOAuthUserProvider.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/apple/AppleOAuthUserProvider.kt
@@ -1,0 +1,30 @@
+package nexters.linkllet.common.support.apple
+
+import io.jsonwebtoken.Claims
+import nexters.linkllet.common.exception.dto.UnauthorizedException
+import org.springframework.stereotype.Component
+
+@Component
+class AppleOAuthUserProvider(
+        private val appleJwtParser: AppleJwtParser,
+        private val appleClient: AppleClient,
+        private val publicKeyGenerator: PublicKeyGenerator,
+        private val appleClaimsValidator: AppleClaimsValidator,
+) {
+
+    fun getApplePlatformUser(idToken: String): ApplePlatformUser {
+        val headers = appleJwtParser.parseHeaders(idToken)
+        val applePublicKeys = appleClient.getApplePublicKeys()
+
+        val publicKey = publicKeyGenerator.generatePublicKey(headers, applePublicKeys)
+        val claims = appleJwtParser.parsePublicKeyAndGetClaims(idToken, publicKey)
+        validateClaims(claims)
+        return ApplePlatformUser(claims.subject, claims["email"].toString())
+    }
+
+    private fun validateClaims(claims: Claims) {
+        if (!appleClaimsValidator.isValid(claims)) {
+            throw UnauthorizedException("Apple OAuth Claims 값이 올바르지 않습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/nexters/linkllet/common/support/apple/ApplePlatformUserDtos.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/apple/ApplePlatformUserDtos.kt
@@ -1,0 +1,6 @@
+package nexters.linkllet.common.support.apple
+
+data class ApplePlatformUser(
+        val platformId: String,
+        val email: String,
+)

--- a/src/main/kotlin/nexters/linkllet/common/support/apple/ApplePublicKeys.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/apple/ApplePublicKeys.kt
@@ -1,0 +1,25 @@
+package nexters.linkllet.common.support.apple
+
+import nexters.linkllet.common.exception.dto.BadRequestException
+
+data class ApplePublicKeys(
+        val keys: List<ApplePublicKey>,
+) {
+
+    fun getMatchesKey(alg: String?, kid: String?): ApplePublicKey {
+        return keys
+                .stream()
+                .filter { (k, a): ApplePublicKey -> a == alg && k == kid }
+                .findFirst()
+                .orElseThrow { BadRequestException("Apple JWT 값의 alg, kid 정보가 올바르지 않습니다.") }
+    }
+}
+
+data class ApplePublicKey(
+        val kty: String,
+        val kid: String,
+        val use: String,
+        val alg: String,
+        val n: String,
+        val e: String,
+)

--- a/src/main/kotlin/nexters/linkllet/common/support/apple/PublicKeyGenerator.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/apple/PublicKeyGenerator.kt
@@ -1,0 +1,45 @@
+package nexters.linkllet.common.support.apple
+
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.NoSuchAlgorithmException
+import java.security.PublicKey
+import java.security.spec.InvalidKeySpecException
+import java.security.spec.RSAPublicKeySpec
+import org.springframework.stereotype.Component
+import org.springframework.util.Base64Utils
+
+@Component
+class PublicKeyGenerator {
+
+    fun generatePublicKey(headers: Map<String, String>, applePublicKeys: ApplePublicKeys): PublicKey {
+        val applePublicKey =
+                applePublicKeys.getMatchesKey(headers[SIGN_ALGORITHM_HEADER_KEY], headers[KEY_ID_HEADER_KEY])
+        return generatePublicKeyWithApplePublicKey(applePublicKey)
+    }
+
+    private fun generatePublicKeyWithApplePublicKey(publicKey: ApplePublicKey): PublicKey {
+        val nBytes = Base64Utils.decodeFromUrlSafeString(publicKey.n)
+        val eBytes = Base64Utils.decodeFromUrlSafeString(publicKey.e)
+
+        val n = BigInteger(POSITIVE_SIGN_NUMBER, nBytes)
+        val e = BigInteger(POSITIVE_SIGN_NUMBER, eBytes)
+
+        val publicKeySpec = RSAPublicKeySpec(n, e)
+
+        return try {
+            val keyFactory: KeyFactory = KeyFactory.getInstance(publicKey.kty)
+            keyFactory.generatePublic(publicKeySpec)
+        } catch (e: NoSuchAlgorithmException) {
+            throw IllegalStateException("Apple OAuth 로그인 중 public key 생성에 문제가 발생했습니다.")
+        } catch (e: InvalidKeySpecException) {
+            throw IllegalStateException("Apple OAuth 로그인 중 public key 생성에 문제가 발생했습니다.")
+        }
+    }
+
+    companion object {
+        private const val SIGN_ALGORITHM_HEADER_KEY = "alg"
+        private const val KEY_ID_HEADER_KEY = "kid"
+        private const val POSITIVE_SIGN_NUMBER = 1
+    }
+}

--- a/src/main/kotlin/nexters/linkllet/config/AppConfig.kt
+++ b/src/main/kotlin/nexters/linkllet/config/AppConfig.kt
@@ -12,4 +12,9 @@ class AppConfig {
     fun jwtConfigProperties(): JwtConfigProperties {
         return JwtConfigProperties()
     }
+
+    @Bean
+    fun appleOAuthConfigProperties(): AppleOAuthConfigProperties {
+        return AppleOAuthConfigProperties()
+    }
 }

--- a/src/main/kotlin/nexters/linkllet/config/AppleOAuthConfigProperties.kt
+++ b/src/main/kotlin/nexters/linkllet/config/AppleOAuthConfigProperties.kt
@@ -1,0 +1,10 @@
+package nexters.linkllet.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "oauth.apple")
+data class AppleOAuthConfigProperties(
+        var iss: String = "iss",
+        var clientId: String = "aud",
+        var nonce: String = "nonce",
+)

--- a/src/main/kotlin/nexters/linkllet/config/FeignConfig.kt
+++ b/src/main/kotlin/nexters/linkllet/config/FeignConfig.kt
@@ -1,0 +1,10 @@
+package nexters.linkllet.config
+
+import nexters.linkllet.LinklletApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableFeignClients(basePackageClasses = [LinklletApplication::class])
+class FeignConfig {
+}

--- a/src/main/kotlin/nexters/linkllet/member/dto/MemberDtos.kt
+++ b/src/main/kotlin/nexters/linkllet/member/dto/MemberDtos.kt
@@ -15,3 +15,15 @@ data class LoginRequest(
 data class LoginResponse(
         val token: String,
 )
+
+data class AppleLoginRequest(
+        val token: String,
+)
+
+/*
+ * Apple, Kakao 둘 다 LoginResponse 로 통합할지,
+ * 아니면 Apple, Kakao 별도의 res DTO 만들지 고민됨
+ */
+data class AppleLoginResponse(
+        val token: String,
+)

--- a/src/main/kotlin/nexters/linkllet/member/presentation/MemberCommandApi.kt
+++ b/src/main/kotlin/nexters/linkllet/member/presentation/MemberCommandApi.kt
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import nexters.linkllet.common.support.LoginUserEmail
+import nexters.linkllet.member.dto.AppleLoginRequest
+import nexters.linkllet.member.dto.AppleLoginResponse
 import nexters.linkllet.member.dto.LoginRequest
 import nexters.linkllet.member.dto.LoginResponse
 import nexters.linkllet.member.dto.MemberFeedbackRequest
@@ -20,14 +22,14 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/api/v1/members")
 class MemberCommandApi(
-    private val memberService: MemberService,
-    private val authService: AuthService,
+        private val memberService: MemberService,
+        private val authService: AuthService,
 ) {
 
     @Operation(summary = "회원가입")
     @PostMapping
     fun signUp(
-        @RequestBody request: MemberSignUpRequest,
+            @RequestBody request: MemberSignUpRequest,
     ): ResponseEntity<Unit> {
         memberService.signUp(request.email)
         return ResponseEntity.ok().build()
@@ -42,6 +44,15 @@ class MemberCommandApi(
             @RequestBody request: LoginRequest,
     ): ResponseEntity<LoginResponse> {
         val response = authService.login(request)
+        return ResponseEntity.ok().body(response)
+    }
+
+    @Operation(summary = "Apple OAuth 로그인")
+    @PostMapping("/login/apple")
+    fun loginApple(
+            @RequestBody request: AppleLoginRequest,
+    ): ResponseEntity<AppleLoginResponse> {
+        val response = authService.loginApple(request)
         return ResponseEntity.ok().body(response)
     }
 

--- a/src/main/kotlin/nexters/linkllet/member/service/AuthService.kt
+++ b/src/main/kotlin/nexters/linkllet/member/service/AuthService.kt
@@ -1,6 +1,9 @@
 package nexters.linkllet.member.service
 
 import nexters.linkllet.common.support.JwtProvider
+import nexters.linkllet.common.support.apple.AppleOAuthUserProvider
+import nexters.linkllet.member.dto.AppleLoginRequest
+import nexters.linkllet.member.dto.AppleLoginResponse
 import nexters.linkllet.member.dto.LoginRequest
 import nexters.linkllet.member.dto.LoginResponse
 import org.springframework.stereotype.Service
@@ -8,10 +11,17 @@ import org.springframework.stereotype.Service
 @Service
 class AuthService(
         private val jwtTokenProvider: JwtProvider,
+        private val appleOAuthUserProvider: AppleOAuthUserProvider,
 ) {
 
     fun login(request: LoginRequest): LoginResponse {
         val token = jwtTokenProvider.generateToken(request.email)
         return LoginResponse(token)
+    }
+
+    fun loginApple(request: AppleLoginRequest): AppleLoginResponse {
+        val applePlatformUser = appleOAuthUserProvider.getApplePlatformUser(request.token)
+        val token = jwtTokenProvider.generateToken(applePlatformUser.email)
+        return AppleLoginResponse(token)
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,12 @@ security.jwt.token:
   secret-key: ${TOKEN_SECRET_KEY}
   expire-length: ${TOKEN_EXPIRE_LENGTH}
 
+oauth:
+  apple:
+    iss: https://appleid.apple.com
+    client-id: ${OAUTH_APPLE_CLIENT_ID}
+    nonce: ${OAUTH_APPLE_NONCE}
+
 springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json

--- a/src/test/kotlin/nexters/linkllet/common/support/apple/AppleClaimsValidatorTest.kt
+++ b/src/test/kotlin/nexters/linkllet/common/support/apple/AppleClaimsValidatorTest.kt
@@ -1,0 +1,55 @@
+package nexters.linkllet.common.support.apple
+
+import io.jsonwebtoken.Jwts
+import nexters.linkllet.config.AppleOAuthConfigProperties
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+
+class AppleClaimsValidatorTest {
+
+    @Test
+    fun `올바른 Claims 테스트`() {
+        // given
+        val appleOAuthConfigProperties = AppleOAuthConfigProperties()
+        val appleClaimsValidator = AppleClaimsValidator(appleOAuthConfigProperties)
+        val claimsMap: MutableMap<String, Any> = HashMap()
+        claimsMap[NONCE_KEY] = AppleClaimsValidator.encrypt(appleOAuthConfigProperties.nonce)
+
+        val claims = Jwts.claims(claimsMap)
+                .setIssuer(appleOAuthConfigProperties.iss)
+                .setAudience(appleOAuthConfigProperties.clientId)
+
+        // when
+        // then
+        assertThat(appleClaimsValidator.isValid(claims)).isTrue
+    }
+
+    companion object {
+        private const val NONCE_KEY = "nonce"
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "invalid, iss, aud",
+        "nonce, invalid, aud",
+        "nonce, iss, invalid"
+    )
+    fun `잘못된 claims 테스트`(nonce: String, iss: String, aud: String) {
+        // given
+        val appleOAuthConfigProperties = AppleOAuthConfigProperties()
+        val appleClaimsValidator = AppleClaimsValidator(appleOAuthConfigProperties)
+        val claimsMap: MutableMap<String, Any> = HashMap()
+        claimsMap[NONCE_KEY] = AppleClaimsValidator.encrypt(nonce)
+
+        val claims = Jwts.claims(claimsMap)
+                .setIssuer(iss)
+                .setAudience(aud)
+
+        // when
+        // then
+        assertThat(appleClaimsValidator.isValid(claims)).isFalse
+    }
+}

--- a/src/test/kotlin/nexters/linkllet/common/support/apple/AppleClientTest.kt
+++ b/src/test/kotlin/nexters/linkllet/common/support/apple/AppleClientTest.kt
@@ -1,0 +1,17 @@
+package nexters.linkllet.common.support.apple
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+
+@SpringBootTest
+class AppleClientTest(
+        @Autowired val appleClient: AppleClient,
+) {
+    @Test
+    fun `apple 서버와 통신하여 Apple public keys 응답을 받는다`() {
+        assertDoesNotThrow { appleClient.getApplePublicKeys().keys }
+    }
+}

--- a/src/test/kotlin/nexters/linkllet/common/support/apple/AppleJwtParserTest.kt
+++ b/src/test/kotlin/nexters/linkllet/common/support/apple/AppleJwtParserTest.kt
@@ -1,0 +1,119 @@
+package nexters.linkllet.common.support.apple
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import java.security.KeyPairGenerator
+import java.util.*
+import nexters.linkllet.common.exception.dto.UnauthorizedException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AppleJwtParserTest {
+
+    private val appleJwtParser = AppleJwtParser()
+
+    @Test
+    fun `Apple identity token으로 헤더를 파싱한다`() {
+        // given
+        val now = Date()
+        val keyPair = KeyPairGenerator.getInstance("RSA").genKeyPair()
+        val privateKey = keyPair.private
+
+        val idToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(Date(now.time + 1000 * 60 * 60 * 24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact()
+
+        // when
+        val actual = appleJwtParser.parseHeaders(idToken)
+
+        // then
+        assertThat(actual).containsKeys("alg", "kid")
+    }
+
+    @Test
+    fun `올바르지 않은 형식의 Apple identity token으로 헤더를 파싱하면 예외를 반환한다`() {
+        assertThrows<UnauthorizedException> { appleJwtParser.parseHeaders("invalidToken") }
+    }
+
+    @Test
+    fun `Apple identity token, PublicKey를 받아 사용자 정보가 포함된 Claims를 반환한다`() {
+        // given
+        val expected = "11111111"
+        val now = Date()
+        val keyPair = KeyPairGenerator.getInstance("RSA").genKeyPair()
+        val publicKey = keyPair.public
+        val privateKey = keyPair.private
+
+        val idToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject(expected)
+                .setExpiration(Date(now.time + 1000 * 60 * 60 * 24))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact()
+
+        // when
+        val claims = appleJwtParser.parsePublicKeyAndGetClaims(idToken, publicKey)
+
+        // then
+        assertThat(claims.subject).isEqualTo(expected)
+    }
+
+    @Test
+    fun `만료된 Apple identity token을 받으면 Claims 획득 시에 예외를 반환한다`() {
+        // given
+        val now = Date()
+        val keyPair = KeyPairGenerator.getInstance("RSA").genKeyPair()
+        val publicKey = keyPair.public
+        val privateKey = keyPair.private
+
+        val expiredIdToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject("11111111")
+                .setExpiration(Date(now.time - 1))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact()
+
+        // when
+        // then
+        assertThrows<UnauthorizedException> { appleJwtParser.parsePublicKeyAndGetClaims(expiredIdToken, publicKey) }
+    }
+
+    @Test
+    fun `올바르지 않은 public Key로 Claims 획득 시에 예외를 반환한다`() {
+        // given
+        val now = Date()
+        val keyPair = KeyPairGenerator.getInstance("RSA").genKeyPair()
+        val privateKey = keyPair.private
+        val diffPublicKey = KeyPairGenerator.getInstance("RSA").genKeyPair().public
+
+        val expiredIdToken = Jwts.builder()
+                .setHeaderParam("kid", "W2R4HXF3K")
+                .claim("id", "12345678")
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setSubject("11111111")
+                .setExpiration(Date(now.time - 1))
+                .signWith(SignatureAlgorithm.RS256, privateKey)
+                .compact()
+
+        // when
+        // then
+        assertThrows<UnauthorizedException> { appleJwtParser.parsePublicKeyAndGetClaims(expiredIdToken, diffPublicKey) }
+    }
+}

--- a/src/test/kotlin/nexters/linkllet/common/support/apple/AppleJwtParserTest.kt
+++ b/src/test/kotlin/nexters/linkllet/common/support/apple/AppleJwtParserTest.kt
@@ -21,14 +21,14 @@ class AppleJwtParserTest {
         val privateKey = keyPair.private
 
         val idToken = Jwts.builder()
-                .setHeaderParam("kid", "W2R4HXF3K")
-                .claim("id", "12345678")
-                .setIssuer("iss")
-                .setIssuedAt(now)
-                .setAudience("aud")
-                .setExpiration(Date(now.time + 1000 * 60 * 60 * 24))
-                .signWith(SignatureAlgorithm.RS256, privateKey)
-                .compact()
+            .setHeaderParam("kid", "W2R4HXF3K")
+            .claim("id", "12345678")
+            .setIssuer("iss")
+            .setIssuedAt(now)
+            .setAudience("aud")
+            .setExpiration(Date(now.time + 1000 * 60 * 60 * 24))
+            .signWith(privateKey, SignatureAlgorithm.RS256)
+            .compact()
 
         // when
         val actual = appleJwtParser.parseHeaders(idToken)
@@ -52,15 +52,15 @@ class AppleJwtParserTest {
         val privateKey = keyPair.private
 
         val idToken = Jwts.builder()
-                .setHeaderParam("kid", "W2R4HXF3K")
-                .claim("id", "12345678")
-                .setIssuer("iss")
-                .setIssuedAt(now)
-                .setAudience("aud")
-                .setSubject(expected)
-                .setExpiration(Date(now.time + 1000 * 60 * 60 * 24))
-                .signWith(SignatureAlgorithm.RS256, privateKey)
-                .compact()
+            .setHeaderParam("kid", "W2R4HXF3K")
+            .claim("id", "12345678")
+            .setIssuer("iss")
+            .setIssuedAt(now)
+            .setAudience("aud")
+            .setSubject(expected)
+            .setExpiration(Date(now.time + 1000 * 60 * 60 * 24))
+            .signWith(privateKey, SignatureAlgorithm.RS256)
+            .compact()
 
         // when
         val claims = appleJwtParser.parsePublicKeyAndGetClaims(idToken, publicKey)
@@ -78,15 +78,15 @@ class AppleJwtParserTest {
         val privateKey = keyPair.private
 
         val expiredIdToken = Jwts.builder()
-                .setHeaderParam("kid", "W2R4HXF3K")
-                .claim("id", "12345678")
-                .setIssuer("iss")
-                .setIssuedAt(now)
-                .setAudience("aud")
-                .setSubject("11111111")
-                .setExpiration(Date(now.time - 1))
-                .signWith(SignatureAlgorithm.RS256, privateKey)
-                .compact()
+            .setHeaderParam("kid", "W2R4HXF3K")
+            .claim("id", "12345678")
+            .setIssuer("iss")
+            .setIssuedAt(now)
+            .setAudience("aud")
+            .setSubject("11111111")
+            .setExpiration(Date(now.time - 1))
+            .signWith(privateKey, SignatureAlgorithm.RS256)
+            .compact()
 
         // when
         // then
@@ -102,15 +102,15 @@ class AppleJwtParserTest {
         val diffPublicKey = KeyPairGenerator.getInstance("RSA").genKeyPair().public
 
         val expiredIdToken = Jwts.builder()
-                .setHeaderParam("kid", "W2R4HXF3K")
-                .claim("id", "12345678")
-                .setIssuer("iss")
-                .setIssuedAt(now)
-                .setAudience("aud")
-                .setSubject("11111111")
-                .setExpiration(Date(now.time - 1))
-                .signWith(SignatureAlgorithm.RS256, privateKey)
-                .compact()
+            .setHeaderParam("kid", "W2R4HXF3K")
+            .claim("id", "12345678")
+            .setIssuer("iss")
+            .setIssuedAt(now)
+            .setAudience("aud")
+            .setSubject("11111111")
+            .setExpiration(Date(now.time - 1))
+            .signWith(privateKey, SignatureAlgorithm.RS256)
+            .compact()
 
         // when
         // then


### PR DESCRIPTION
close #32 

## 구현한 사항
- FeignClient를 이용하여 Apple OAuth를 구현하였음. [참고한 블로그: kth990303 블로그 ㅋㅋ](https://kth990303.tistory.com/437) 

## 추가로 구현이 필요한 사항
- `AppleOAuthUserProvider`, apple 로그인 API 테스트가 없음.
- 현재는 애플리케이션 테스트 불가능. iOS 측에서 client-id, nonce 값을 확정지은 후 전달해주어야 함. 해당 값 전달받으면 테스트 가능할 것으로 보임.
  -  해당 값 받고 테스트 및 코드리뷰해주어도 괜찮을 듯