### PR TITLE
feat: apple oauth nonce 제거

### DIFF
--- a/src/main/kotlin/nexters/linkllet/common/support/apple/AppleClaimsValidator.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/apple/AppleClaimsValidator.kt
@@ -1,40 +1,16 @@
 package nexters.linkllet.common.support.apple
 
 import io.jsonwebtoken.Claims
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
-import java.security.NoSuchAlgorithmException
+import nexters.linkllet.config.AppleOAuthConfigProperties
 import org.springframework.stereotype.Component
 
 @Component
 class AppleClaimsValidator(
-        private val appleOAuthConfigProperties: AppleOAuthConfigProperties,
+    private val appleOAuthConfigProperties: AppleOAuthConfigProperties,
 ) {
 
     fun isValid(claims: Claims): Boolean {
         return claims.issuer.contains(appleOAuthConfigProperties.iss) &&
-                claims.audience == appleOAuthConfigProperties.clientId &&
-                claims.get(NONCE_KEY, String::class.java) == encrypt(appleOAuthConfigProperties.nonce);
-    }
-
-    companion object {
-        fun encrypt(nonce: String): String {
-            return try {
-                val sha256 = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM)
-                val digest = sha256.digest(nonce.toByteArray(StandardCharsets.UTF_8))
-                val hexString = StringBuilder()
-                for (b in digest) {
-                    hexString.append(String.format(HEX_STRING_FORMAT, b))
-                }
-                hexString.toString()
-            } catch (e: NoSuchAlgorithmException) {
-                throw IllegalArgumentException("Apple OAuth 통신 암호화 과정 중 문제가 발생했습니다.")
-            }
-        }
-
-        private const val MESSAGE_DIGEST_ALGORITHM = "SHA-256"
-        private const val HEX_STRING_FORMAT = "%02x"
-
-        private const val NONCE_KEY = "nonce"
+                claims.audience == appleOAuthConfigProperties.clientId
     }
 }

--- a/src/main/kotlin/nexters/linkllet/common/support/apple/AppleJwtParser.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/apple/AppleJwtParser.kt
@@ -27,7 +27,7 @@ class AppleJwtParser {
             * Java 에서는 "." 안없애도 에러가 안뜨지만 kotlin 은 에러 발생. 왜 발생하는 것인지 추후 확인 필요
             */
             val decodedHeader =
-                    String(Base64Utils.decodeFromUrlSafeString(encodedHeader.replace(".", "")))
+                String(Base64Utils.decodeFromUrlSafeString(encodedHeader.replace(".", "")))
             return OBJECT_MAPPER.readValue(decodedHeader)
         } catch (e: JsonProcessingException) {
             throw UnauthorizedException("Apple OAuth Identity Token 형식이 올바르지 않습니다.")
@@ -38,10 +38,11 @@ class AppleJwtParser {
 
     fun parsePublicKeyAndGetClaims(idToken: String, publicKey: PublicKey): Claims {
         return try {
-            Jwts.parser()
-                    .setSigningKey(publicKey)
-                    .parseClaimsJws(idToken)
-                    .body
+            Jwts.parserBuilder()
+                .setSigningKey(publicKey)
+                .build()
+                .parseClaimsJws(idToken)
+                .body
         } catch (e: ExpiredJwtException) {
             throw UnauthorizedException("Apple OAuth 로그인 중 Identity Token 유효기간이 만료됐습니다.")
         } catch (e: UnsupportedJwtException) {

--- a/src/main/kotlin/nexters/linkllet/config/AppleOAuthConfigProperties.kt
+++ b/src/main/kotlin/nexters/linkllet/config/AppleOAuthConfigProperties.kt
@@ -1,0 +1,9 @@
+package nexters.linkllet.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "oauth.apple")
+data class AppleOAuthConfigProperties(
+    var iss: String = "iss",
+    var clientId: String = "aud"
+)

--- a/src/test/kotlin/nexters/linkllet/common/support/apple/AppleClaimsValidatorTest.kt
+++ b/src/test/kotlin/nexters/linkllet/common/support/apple/AppleClaimsValidatorTest.kt
@@ -15,37 +15,30 @@ class AppleClaimsValidatorTest {
         val appleOAuthConfigProperties = AppleOAuthConfigProperties()
         val appleClaimsValidator = AppleClaimsValidator(appleOAuthConfigProperties)
         val claimsMap: MutableMap<String, Any> = HashMap()
-        claimsMap[NONCE_KEY] = AppleClaimsValidator.encrypt(appleOAuthConfigProperties.nonce)
 
         val claims = Jwts.claims(claimsMap)
-                .setIssuer(appleOAuthConfigProperties.iss)
-                .setAudience(appleOAuthConfigProperties.clientId)
+            .setIssuer(appleOAuthConfigProperties.iss)
+            .setAudience(appleOAuthConfigProperties.clientId)
 
         // when
         // then
         assertThat(appleClaimsValidator.isValid(claims)).isTrue
     }
 
-    companion object {
-        private const val NONCE_KEY = "nonce"
-    }
-
     @ParameterizedTest
     @CsvSource(
-        "invalid, iss, aud",
-        "nonce, invalid, aud",
-        "nonce, iss, invalid"
+        "invalid, aud",
+        "iss, invalid"
     )
-    fun `잘못된 claims 테스트`(nonce: String, iss: String, aud: String) {
+    fun `잘못된 claims 테스트`(iss: String, aud: String) {
         // given
         val appleOAuthConfigProperties = AppleOAuthConfigProperties()
         val appleClaimsValidator = AppleClaimsValidator(appleOAuthConfigProperties)
         val claimsMap: MutableMap<String, Any> = HashMap()
-        claimsMap[NONCE_KEY] = AppleClaimsValidator.encrypt(nonce)
 
         val claims = Jwts.claims(claimsMap)
-                .setIssuer(iss)
-                .setAudience(aud)
+            .setIssuer(iss)
+            .setAudience(aud)
 
         // when
         // then


### PR DESCRIPTION
close #45 

## 구현사항
- apple oauth nonce 값 제거
  - random한 nonce를 해싱하여 클라 쪽에서 보내줄 경우, 서버 측에서 (nonce가 매번 random하므로) 올바른 nonce인지 확인이 어려움. 클라 쪽과 협의 후 nonce 검증 제거하기로 결정
    - public key, private key, claims 검증 작업은 여전히 존재

## 추가 당부
- apple oauth 머지 후, 혹시나 서버 측 에러가 터지면 이슈 생성 후 카톡으로 알려주시면 바로 작업 들어갈게요~~