### PR TITLE
feat: create kakao oauth sdk

### DIFF
--- a/src/main/kotlin/nexters/linkllet/common/exception/dto/ErrorDtos.kt
+++ b/src/main/kotlin/nexters/linkllet/common/exception/dto/ErrorDtos.kt
@@ -20,5 +20,4 @@ class ForbiddenException(message: String = "권한이 존재하지 않습니다.
 class NotFoundException(message: String = "존재하지 않는 요청입니다.")
     : LinklletException(message, HttpStatus.NOT_FOUND.value())
 
-class ConflictException(message: String = "이미 등록된 이메일입니다.")
-    : LinklletException(message, HttpStatus.CONFLICT.value())
+class ConflictException(message: String = "이미 등록된 사용자 입니다.") : LinklletException(message, HttpStatus.CONFLICT.value())

--- a/src/main/kotlin/nexters/linkllet/common/support/AuthorizationExtractor.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/AuthorizationExtractor.kt
@@ -1,7 +1,7 @@
 package nexters.linkllet.common.support
 
-import javax.servlet.http.HttpServletRequest
 import nexters.linkllet.common.exception.dto.UnauthorizedException
+import javax.servlet.http.HttpServletRequest
 
 class AuthorizationExtractor {
 
@@ -9,6 +9,7 @@ class AuthorizationExtractor {
 
         private const val AUTHENTICATION_TYPE = "Bearer"
         private const val AUTHORIZATION_HEADER_KEY = "Authorization"
+        private const val EMPTY_TOKEN = ""
         private const val START_TOKEN_INDEX = 6
 
         fun extractToken(request: HttpServletRequest): String {
@@ -22,7 +23,8 @@ class AuthorizationExtractor {
                     return extractToken
                 }
             }
-            throw UnauthorizedException()
+
+            return EMPTY_TOKEN
         }
 
         private fun validateStartsAuthorizationKey(value: String) =

--- a/src/main/kotlin/nexters/linkllet/common/support/DeviceHeaderExtractor.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/DeviceHeaderExtractor.kt
@@ -1,0 +1,16 @@
+package nexters.linkllet.common.support
+
+import javax.servlet.http.HttpServletRequest
+
+class DeviceHeaderExtractor {
+
+    companion object {
+        private const val DEVICE_ID_HEADER = "Device-Id"
+        private const val EMPTY_TOKEN = ""
+
+        fun extractDeviceId(request: HttpServletRequest): String {
+            return request.getHeader(DEVICE_ID_HEADER)
+                ?: return EMPTY_TOKEN
+        }
+    }
+}

--- a/src/main/kotlin/nexters/linkllet/common/support/DeviceHeaderExtractor.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/DeviceHeaderExtractor.kt
@@ -10,7 +10,7 @@ class DeviceHeaderExtractor {
 
         fun extractDeviceId(request: HttpServletRequest): String {
             return request.getHeader(DEVICE_ID_HEADER)
-                ?: return EMPTY_TOKEN
+                ?: EMPTY_TOKEN
         }
     }
 }

--- a/src/main/kotlin/nexters/linkllet/common/support/LoginUser.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/LoginUser.kt
@@ -5,4 +5,4 @@ import io.swagger.v3.oas.annotations.Hidden
 @Hidden
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class LoginUserEmail
+annotation class LoginUser

--- a/src/main/kotlin/nexters/linkllet/common/support/LoginUserResolver.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/LoginUserResolver.kt
@@ -1,12 +1,13 @@
 package nexters.linkllet.common.support
 
-import javax.servlet.http.HttpServletRequest
+import nexters.linkllet.common.exception.dto.UnauthorizedException
 import org.springframework.core.MethodParameter
 import org.springframework.stereotype.Component
 import org.springframework.web.bind.support.WebDataBinderFactory
 import org.springframework.web.context.request.NativeWebRequest
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
 import org.springframework.web.method.support.ModelAndViewContainer
+import javax.servlet.http.HttpServletRequest
 
 @Component
 class LoginUserResolver(
@@ -14,7 +15,7 @@ class LoginUserResolver(
 ) : HandlerMethodArgumentResolver {
 
     override fun supportsParameter(parameter: MethodParameter): Boolean {
-        return parameter.hasParameterAnnotation(LoginUserEmail::class.java)
+        return parameter.hasParameterAnnotation(LoginUser::class.java)
     }
 
     override fun resolveArgument(
@@ -24,7 +25,16 @@ class LoginUserResolver(
             binderFactory: WebDataBinderFactory?,
     ): String {
         val request = webRequest.nativeRequest as HttpServletRequest
-        val token = AuthorizationExtractor.extractToken(request)
-        return jwtProvider.getPayload(token)
+
+        val deviceId = DeviceHeaderExtractor.extractDeviceId(request)
+        val jwtToken = AuthorizationExtractor.extractToken(request)
+
+        if (hasBothDeviceIdAndToken(deviceId, jwtToken)) throw UnauthorizedException()
+        else if (deviceId.isNullOrBlank()) return jwtProvider.getPayload(jwtToken)
+        else if (jwtToken.isNullOrBlank()) return deviceId
+        else throw UnauthorizedException()
     }
+
+    private fun hasBothDeviceIdAndToken(deviceId: String, jwtToken: String) =
+        !deviceId.isNullOrBlank() && !jwtToken.isNullOrBlank()
 }

--- a/src/main/kotlin/nexters/linkllet/common/support/LoginUserResolver.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/LoginUserResolver.kt
@@ -30,11 +30,15 @@ class LoginUserResolver(
         val jwtToken = AuthorizationExtractor.extractToken(request)
 
         if (hasBothDeviceIdAndToken(deviceId, jwtToken)) throw UnauthorizedException()
-        else if (deviceId.isNullOrBlank()) return jwtProvider.getPayload(jwtToken)
-        else if (jwtToken.isNullOrBlank()) return deviceId
+        else if (isAppleOAuthLogin(deviceId)) return jwtProvider.getPayload(jwtToken)
+        else if (isKakaoOAuthLogin(jwtToken)) return deviceId
         else throw UnauthorizedException()
     }
 
     private fun hasBothDeviceIdAndToken(deviceId: String, jwtToken: String) =
         !deviceId.isNullOrBlank() && !jwtToken.isNullOrBlank()
+
+    private fun isAppleOAuthLogin(deviceId: String) = deviceId.isNullOrBlank()
+
+    private fun isKakaoOAuthLogin(jwtToken: String) = jwtToken.isNullOrBlank()
 }

--- a/src/main/kotlin/nexters/linkllet/common/support/apple/AppleClaimsValidator.kt
+++ b/src/main/kotlin/nexters/linkllet/common/support/apple/AppleClaimsValidator.kt
@@ -1,7 +1,6 @@
 package nexters.linkllet.common.support.apple
 
 import io.jsonwebtoken.Claims
-import nexters.linkllet.config.AppleOAuthConfigProperties
 import org.springframework.stereotype.Component
 
 @Component

--- a/src/main/kotlin/nexters/linkllet/config/SwaggerConfiguration.kt
+++ b/src/main/kotlin/nexters/linkllet/config/SwaggerConfiguration.kt
@@ -12,23 +12,36 @@ import org.springframework.http.HttpHeaders
 @Configuration
 class SwaggerConfiguration {
 
+    companion object {
+        private const val DEVICE_ID_HEADER = "Device-Id"
+    }
+
     @Bean
     fun api(): OpenAPI {
         val info = Info()
-                .title("Linkllet 백엔드 API 명세")
-                .description("springdoc을 이용한 Swagger API 문서입니다.")
-                .version("1.0")
-                .contact(Contact().name("springdoc 공식문서").url("https://springdoc.org/"))
+            .title("Linkllet 백엔드 API 명세")
+            .description("springdoc을 이용한 Swagger API 문서입니다.")
+            .version("1.2.0")
+            .contact(Contact().name("springdoc 공식문서").url("https://springdoc.org/"))
 
-        val deviceHeader = SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT")
-                .`in`(SecurityScheme.In.HEADER)
-                .name(HttpHeaders.AUTHORIZATION)
+        val deviceIdHeader = SecurityScheme()
+            .type(SecurityScheme.Type.APIKEY)
+            .`in`(SecurityScheme.In.HEADER)
+            .name(DEVICE_ID_HEADER)
+
+        val deviceTokenHeader = SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .`in`(SecurityScheme.In.HEADER)
+            .name(HttpHeaders.AUTHORIZATION)
 
         return OpenAPI()
-                .components(Components().addSecuritySchemes("JWT", deviceHeader))
+            .components(
+                Components()
+                    .addSecuritySchemes("JWT", deviceTokenHeader)
+                    .addSecuritySchemes(DEVICE_ID_HEADER, deviceIdHeader)
+            )
                 .info(info)
     }
 }

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderCommandApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderCommandApi.kt
@@ -3,7 +3,7 @@ package nexters.linkllet.folder.presentation
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import nexters.linkllet.common.support.LoginUserEmail
+import nexters.linkllet.common.support.LoginUser
 import nexters.linkllet.folder.dto.ArticleCreateRequest
 import nexters.linkllet.folder.dto.FolderCreateRequest
 import nexters.linkllet.folder.dto.FolderUpdateRequest
@@ -22,10 +22,10 @@ class FolderCommandApi(
     @SecurityRequirement(name = "JWT")
     @PostMapping
     fun createFolder(
-            @RequestBody request: FolderCreateRequest,
-            @LoginUserEmail email: String,
+        @RequestBody request: FolderCreateRequest,
+        @LoginUser userCode: String,
     ): ResponseEntity<Unit> {
-        folderService.createFolder(request.name, email)
+        folderService.createFolder(request.name, userCode)
         return ResponseEntity.ok().build()
     }
 
@@ -33,11 +33,11 @@ class FolderCommandApi(
     @SecurityRequirement(name = "Device-Id")
     @PutMapping("/{id}")
     fun updateFolder(
-            @PathVariable id: Long,
-            @RequestBody request: FolderUpdateRequest,
-            @LoginUserEmail email: String,
+        @PathVariable id: Long,
+        @RequestBody request: FolderUpdateRequest,
+        @LoginUser userCode: String,
     ): ResponseEntity<Unit> {
-        folderService.updateFolderName(id, request.updateName, email)
+        folderService.updateFolderName(id, request.updateName, userCode)
         return ResponseEntity.noContent().build()
     }
 
@@ -45,10 +45,10 @@ class FolderCommandApi(
     @SecurityRequirement(name = "JWT")
     @DeleteMapping("/{id}")
     fun deleteFolder(
-            @PathVariable id: Long,
-            @LoginUserEmail email: String,
+        @PathVariable id: Long,
+        @LoginUser userCode: String,
     ): ResponseEntity<Unit> {
-        folderService.deleteFolder(id, email)
+        folderService.deleteFolder(id, userCode)
         return ResponseEntity.noContent().build()
     }
 
@@ -56,11 +56,11 @@ class FolderCommandApi(
     @SecurityRequirement(name = "JWT")
     @PostMapping("/{id}/articles")
     fun createArticle(
-            @PathVariable id: Long,
-            @RequestBody request: ArticleCreateRequest,
-            @LoginUserEmail email: String,
+        @PathVariable id: Long,
+        @RequestBody request: ArticleCreateRequest,
+        @LoginUser userCode: String,
     ): ResponseEntity<Unit> {
-        folderService.addArticleAtFolder(id, request.name, request.url, email)
+        folderService.addArticleAtFolder(id, request.name, request.url, userCode)
         return ResponseEntity.ok().build()
     }
 
@@ -68,11 +68,11 @@ class FolderCommandApi(
     @SecurityRequirement(name = "JWT")
     @DeleteMapping("/{id}/articles/{articleId}")
     fun createArticle(
-            @PathVariable id: Long,
-            @PathVariable articleId: Long,
-            @LoginUserEmail email: String,
+        @PathVariable id: Long,
+        @PathVariable articleId: Long,
+        @LoginUser userCode: String,
     ): ResponseEntity<Unit> {
-        folderService.deleteArticleAtFolder(id, articleId, email)
+        folderService.deleteArticleAtFolder(id, articleId, userCode)
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderCommandApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderCommandApi.kt
@@ -20,6 +20,7 @@ class FolderCommandApi(
 
     @Operation(summary = "폴더 생성")
     @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Device-Id")
     @PostMapping
     fun createFolder(
         @RequestBody request: FolderCreateRequest,
@@ -30,6 +31,7 @@ class FolderCommandApi(
     }
 
     @Operation(summary = "폴더명 변경")
+    @SecurityRequirement(name = "JWT")
     @SecurityRequirement(name = "Device-Id")
     @PutMapping("/{id}")
     fun updateFolder(
@@ -43,6 +45,7 @@ class FolderCommandApi(
 
     @Operation(summary = "폴더 삭제")
     @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Device-Id")
     @DeleteMapping("/{id}")
     fun deleteFolder(
         @PathVariable id: Long,
@@ -54,6 +57,7 @@ class FolderCommandApi(
 
     @Operation(summary = "링크 생성")
     @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Device-Id")
     @PostMapping("/{id}/articles")
     fun createArticle(
         @PathVariable id: Long,
@@ -66,6 +70,7 @@ class FolderCommandApi(
 
     @Operation(summary = "링크 삭제")
     @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Device-Id")
     @DeleteMapping("/{id}/articles/{articleId}")
     fun createArticle(
         @PathVariable id: Long,

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
@@ -19,6 +19,7 @@ class FolderQueryApi(
 
     @Operation(summary = "폴더 목록 조회")
     @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Device-Id")
     @GetMapping
     fun lookUpFolderList(
         @LoginUser userCode: String,
@@ -29,6 +30,7 @@ class FolderQueryApi(
 
     @Operation(summary = "기사 목록 조회")
     @SecurityRequirement(name = "JWT")
+    @SecurityRequirement(name = "Device-Id")
     @GetMapping("/{id}/articles")
     fun lookUpArticleList(
         @PathVariable id: Long,
@@ -39,6 +41,7 @@ class FolderQueryApi(
     }
 
     @Operation(summary = "링크 검색")
+    @SecurityRequirement(name = "JWT")
     @SecurityRequirement(name = "Device-Id")
     @GetMapping("/search")
     fun searchArticles(

--- a/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/presentation/FolderQueryApi.kt
@@ -3,7 +3,7 @@ package nexters.linkllet.folder.presentation
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import nexters.linkllet.common.support.LoginUserEmail
+import nexters.linkllet.common.support.LoginUser
 import nexters.linkllet.folder.dto.ArticleLookupListResponse
 import nexters.linkllet.folder.dto.FolderLookupListResponse
 import nexters.linkllet.folder.service.FolderService
@@ -21,9 +21,9 @@ class FolderQueryApi(
     @SecurityRequirement(name = "JWT")
     @GetMapping
     fun lookUpFolderList(
-            @LoginUserEmail email: String,
+        @LoginUser userCode: String,
     ): ResponseEntity<FolderLookupListResponse> {
-        val lookupDtoList = folderService.lookupFolderList(email)
+        val lookupDtoList = folderService.lookupFolderList(userCode)
         return ResponseEntity.ok().body(lookupDtoList)
     }
 
@@ -31,10 +31,10 @@ class FolderQueryApi(
     @SecurityRequirement(name = "JWT")
     @GetMapping("/{id}/articles")
     fun lookUpArticleList(
-            @PathVariable id: Long,
-            @LoginUserEmail email: String,
+        @PathVariable id: Long,
+        @LoginUser userCode: String,
     ): ResponseEntity<ArticleLookupListResponse> {
-        val lookupDtoList = folderService.lookupArticleList(id, email)
+        val lookupDtoList = folderService.lookupArticleList(id, userCode)
         return ResponseEntity.ok().body(lookupDtoList)
     }
 
@@ -43,9 +43,9 @@ class FolderQueryApi(
     @GetMapping("/search")
     fun searchArticles(
         @RequestParam content: String,
-        @LoginUserEmail email: String,
+        @LoginUser userCode: String,
     ): ResponseEntity<ArticleLookupListResponse> {
-        val lookupDtoList = folderService.searchArticlesByContent(content, email)
+        val lookupDtoList = folderService.searchArticlesByContent(content, userCode)
         return ResponseEntity.ok().body(lookupDtoList)
     }
 }

--- a/src/main/kotlin/nexters/linkllet/folder/service/FolderService.kt
+++ b/src/main/kotlin/nexters/linkllet/folder/service/FolderService.kt
@@ -11,7 +11,7 @@ import nexters.linkllet.folder.dto.ArticleLookupListResponse
 import nexters.linkllet.folder.dto.FolderLookupListResponse
 import nexters.linkllet.member.domain.Member
 import nexters.linkllet.member.domain.MemberRepository
-import nexters.linkllet.member.domain.findByEmailOrThrow
+import nexters.linkllet.member.domain.findByDeviceIdOrThrow
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -26,8 +26,8 @@ class FolderService(
         private val SPACE_REGEX = "\\s+".toRegex()
     }
 
-    fun createFolder(folderName: String, email: String) {
-        val findMember = memberRepository.findByEmailOrThrow(email)
+    fun createFolder(folderName: String, deviceId: String) {
+        val findMember = memberRepository.findByDeviceIdOrThrow(deviceId)
 
         validateDuplicateFolderName(findMember, folderName)
 
@@ -35,15 +35,15 @@ class FolderService(
     }
 
     @Transactional(readOnly = true)
-    fun lookupFolderList(email: String): FolderLookupListResponse {
-        val findMember = memberRepository.findByEmailOrThrow(email)
+    fun lookupFolderList(deviceId: String): FolderLookupListResponse {
+        val findMember = memberRepository.findByDeviceIdOrThrow(deviceId)
 
         return folderRepository.lookupFolderDtosByMemberId(findMember.getId)
-                .let(::FolderLookupListResponse)
+            .let(::FolderLookupListResponse)
     }
 
-    fun updateFolderName(folderId: Long, updateName: String, email: String) {
-        val findMember = memberRepository.findByEmailOrThrow(email)
+    fun updateFolderName(folderId: Long, updateName: String, deviceId: String) {
+        val findMember = memberRepository.findByDeviceIdOrThrow(deviceId)
         validateDuplicateFolderName(findMember, updateName)
 
         val findFolder = folderRepository.findByIdOrThrow(folderId)
@@ -57,40 +57,40 @@ class FolderService(
     }
 
 
-    fun deleteFolder(folderId: Long, email: String) {
-        val findMember = memberRepository.findByEmailOrThrow(email)
+    fun deleteFolder(folderId: Long, deviceId: String) {
+        val findMember = memberRepository.findByDeviceIdOrThrow(deviceId)
 
         folderRepository.deleteByMemberIdAndId(findMember.getId, folderId)
     }
 
-    fun addArticleAtFolder(folderId: Long, name: String, url: String, email: String) {
-        val findMember = memberRepository.findByEmailOrThrow(email)
+    fun addArticleAtFolder(folderId: Long, name: String, url: String, deviceId: String) {
+        val findMember = memberRepository.findByDeviceIdOrThrow(deviceId)
         val findFolder = folderRepository.findByIdOrThrow(folderId)
 
         findFolder.addArticle(Article(url, name, findMember.getId, findFolder))
     }
 
     @Transactional(readOnly = true)
-    fun lookupArticleList(folderId: Long, email: String): ArticleLookupListResponse {
+    fun lookupArticleList(folderId: Long, deviceId: String): ArticleLookupListResponse {
         return folderRepository.findByIdOrThrow(folderId)
-                .getArticles()
-                .map { ArticleLookupDto.of(it) }
-                .let(::ArticleLookupListResponse)
+            .getArticles()
+            .map { ArticleLookupDto.of(it) }
+            .let(::ArticleLookupListResponse)
     }
 
-    fun deleteArticleAtFolder(folderId: Long, articleId: Long, email: String) {
-        val findMember = memberRepository.findByEmailOrThrow(email)
+    fun deleteArticleAtFolder(folderId: Long, articleId: Long, deviceId: String) {
+        val findMember = memberRepository.findByDeviceIdOrThrow(deviceId)
         val findFolder = folderRepository.findByIdOrThrow(folderId)
 
         findFolder.deleteArticleById(articleId, findMember.getId)
     }
 
     @Transactional(readOnly = true)
-    fun searchArticlesByContent(content: String, email: String): ArticleLookupListResponse {
-        val findMember = memberRepository.findByEmailOrThrow(email)
+    fun searchArticlesByContent(content: String, deviceId: String): ArticleLookupListResponse {
+        val findMember = memberRepository.findByDeviceIdOrThrow(deviceId)
 
         val searchResults = articleQueryRepository
-                .searchAllArticleByKeywords(splitBySpace(content), findMember.getId)
+            .searchAllArticleByKeywords(splitBySpace(content), findMember.getId)
 
         return ArticleLookupListResponse(searchResults)
     }

--- a/src/main/kotlin/nexters/linkllet/member/domain/Member.kt
+++ b/src/main/kotlin/nexters/linkllet/member/domain/Member.kt
@@ -14,13 +14,10 @@ import javax.persistence.Table
 class Member(
 
     /*
-     * OAuth 최종 완료 후, deviceId 요청이 없다고 판단되면 삭제할 것
+     * deviceId는 사용자 인식 필드로, email이나 기기 고유값 모두 가능하다
      */
-    @Column(name = "device_id")
+    @Column(name = "device_id", nullable = false)
     private val deviceId: String? = null,
-
-    @Column(name = "email", length = 100, nullable = false)
-    private val email: String,
 
     @Id
     @Column(name = "member_id")

--- a/src/main/kotlin/nexters/linkllet/member/domain/MemberRepository.kt
+++ b/src/main/kotlin/nexters/linkllet/member/domain/MemberRepository.kt
@@ -7,13 +7,7 @@ fun MemberRepository.findByDeviceIdOrThrow(deviceId: String): Member {
     return findByDeviceId(deviceId) ?: throw NotFoundException("회원이 없어요")
 }
 
-fun MemberRepository.findByEmailOrThrow(email: String): Member {
-    return findByEmail(email) ?: throw NotFoundException("회원이 없어요")
-}
-
 interface MemberRepository : JpaRepository<Member, Long> {
 
     fun findByDeviceId(deviceId: String): Member?
-
-    fun findByEmail(email: String): Member?
 }

--- a/src/main/kotlin/nexters/linkllet/member/dto/MemberDtos.kt
+++ b/src/main/kotlin/nexters/linkllet/member/dto/MemberDtos.kt
@@ -1,7 +1,7 @@
 package nexters.linkllet.member.dto
 
 data class MemberSignUpRequest(
-        val email: String,
+        val deviceId: String,
 )
 
 data class MemberFeedbackRequest(
@@ -9,7 +9,7 @@ data class MemberFeedbackRequest(
 )
 
 data class LoginRequest(
-        val email: String,
+        val deviceId: String,
 )
 
 data class LoginResponse(

--- a/src/main/kotlin/nexters/linkllet/member/presentation/MemberCommandApi.kt
+++ b/src/main/kotlin/nexters/linkllet/member/presentation/MemberCommandApi.kt
@@ -3,13 +3,13 @@ package nexters.linkllet.member.presentation
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import nexters.linkllet.common.support.LoginUserEmail
+import nexters.linkllet.common.support.LoginUser
 import nexters.linkllet.member.dto.AppleLoginRequest
-import nexters.linkllet.member.dto.OAuthLoginResponse
 import nexters.linkllet.member.dto.LoginRequest
 import nexters.linkllet.member.dto.LoginResponse
 import nexters.linkllet.member.dto.MemberFeedbackRequest
 import nexters.linkllet.member.dto.MemberSignUpRequest
+import nexters.linkllet.member.dto.OAuthLoginResponse
 import nexters.linkllet.member.service.AuthService
 import nexters.linkllet.member.service.MemberService
 import org.springframework.http.ResponseEntity
@@ -71,10 +71,10 @@ class MemberCommandApi(
     @SecurityRequirement(name = "Device-Id")
     @PostMapping("/feedbacks")
     fun addFeedback(
-            @RequestBody request: MemberFeedbackRequest,
-            @LoginUserEmail email: String,
+        @RequestBody request: MemberFeedbackRequest,
+        @LoginUser userCode: String,
     ): ResponseEntity<Unit> {
-        memberService.addFeedback(email, request.feedback)
+        memberService.addFeedback(userCode, request.feedback)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/nexters/linkllet/member/presentation/MemberCommandApi.kt
+++ b/src/main/kotlin/nexters/linkllet/member/presentation/MemberCommandApi.kt
@@ -13,11 +13,9 @@ import nexters.linkllet.member.dto.OAuthLoginResponse
 import nexters.linkllet.member.service.AuthService
 import nexters.linkllet.member.service.MemberService
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "Members", description = "회원")
@@ -55,15 +53,6 @@ class MemberCommandApi(
             @RequestBody request: AppleLoginRequest,
     ): ResponseEntity<OAuthLoginResponse> {
         val response = authService.loginApple(request)
-        return ResponseEntity.ok().body(response)
-    }
-
-    @Operation(summary = "Kakao OAuth 로그인")
-    @GetMapping("/login/kakao")
-    fun kakaoCallback(
-        @RequestParam code: String,
-    ): ResponseEntity<OAuthLoginResponse> {
-        val response = authService.loginKakao(code)
         return ResponseEntity.ok().body(response)
     }
 

--- a/src/main/kotlin/nexters/linkllet/member/presentation/MemberCommandApi.kt
+++ b/src/main/kotlin/nexters/linkllet/member/presentation/MemberCommandApi.kt
@@ -33,7 +33,7 @@ class MemberCommandApi(
     fun signUp(
             @RequestBody request: MemberSignUpRequest,
     ): ResponseEntity<Unit> {
-        memberService.signUp(request.email)
+        memberService.signUp(request.deviceId)
         return ResponseEntity.ok().build()
     }
 
@@ -68,13 +68,14 @@ class MemberCommandApi(
     }
 
     @Operation(summary = "피드백 생성")
+    @SecurityRequirement(name = "JWT")
     @SecurityRequirement(name = "Device-Id")
     @PostMapping("/feedbacks")
     fun addFeedback(
         @RequestBody request: MemberFeedbackRequest,
-        @LoginUser userCode: String,
+        @LoginUser deviceId: String,
     ): ResponseEntity<Unit> {
-        memberService.addFeedback(userCode, request.feedback)
+        memberService.addFeedback(deviceId, request.feedback)
         return ResponseEntity.ok().build()
     }
 }

--- a/src/main/kotlin/nexters/linkllet/member/service/AuthService.kt
+++ b/src/main/kotlin/nexters/linkllet/member/service/AuthService.kt
@@ -24,7 +24,7 @@ class AuthService(
 ) {
 
     fun login(request: LoginRequest): LoginResponse {
-        val token = jwtTokenProvider.generateToken(request.email)
+        val token = jwtTokenProvider.generateToken(request.deviceId)
         return LoginResponse(token)
     }
 
@@ -42,8 +42,8 @@ class AuthService(
         return OAuthLoginResponse(token)
     }
 
-    private fun initMember(email: String) {
-        val newMember = memberRepository.save(Member(email = email))
+    private fun initMember(deviceId: String) {
+        val newMember = memberRepository.save(Member(deviceId))
         createStartFolder(newMember)
     }
 

--- a/src/main/kotlin/nexters/linkllet/member/service/MemberService.kt
+++ b/src/main/kotlin/nexters/linkllet/member/service/MemberService.kt
@@ -6,7 +6,7 @@ import nexters.linkllet.folder.domain.FolderRepository
 import nexters.linkllet.folder.domain.FolderType
 import nexters.linkllet.member.domain.Member
 import nexters.linkllet.member.domain.MemberRepository
-import nexters.linkllet.member.domain.findByEmailOrThrow
+import nexters.linkllet.member.domain.findByDeviceIdOrThrow
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,30 +19,30 @@ class MemberService(
         private val folderRepository: FolderRepository,
 ) {
 
-    fun signUp(email: String) {
-        memberRepository.findByEmail(email)
-                ?.let { throw ConflictException() }
+    fun signUp(deviceId: String) {
+        memberRepository.findByDeviceId(deviceId)
+            ?.let { throw ConflictException() }
 
-        initMember(email)
+        initMember(deviceId)
     }
 
-    private fun initMember(email: String) {
-        val newMember = memberRepository.save(Member(email = email))
-        createStartFolder(newMember)
-    }
-
-    fun addFeedback(email: String, feedback: String) {
-        val findMember = memberRepository.findByEmailOrThrow(email)
+    fun addFeedback(deviceId: String, feedback: String) {
+        val findMember = memberRepository.findByDeviceIdOrThrow(deviceId)
         findMember.addFeedback(feedback)
+    }
+
+    private fun initMember(deviceId: String) {
+        val newMember = memberRepository.save(Member(deviceId))
+        createStartFolder(newMember)
     }
 
     private fun createStartFolder(newMember: Member) {
         folderRepository.saveAll(
-                listOf(
-                        Folder(DEFAULT_FOLDER_NAME, newMember.getId, FolderType.DEFAULT),
-                        Folder("Folder 1", newMember.getId, FolderType.PERSONALIZED),
-                        Folder("Folder 2", newMember.getId, FolderType.PERSONALIZED)
-                )
+            listOf(
+                Folder(DEFAULT_FOLDER_NAME, newMember.getId, FolderType.DEFAULT),
+                Folder("Folder 1", newMember.getId, FolderType.PERSONALIZED),
+                Folder("Folder 2", newMember.getId, FolderType.PERSONALIZED)
+            )
         )
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true

--- a/src/test/kotlin/nexters/linkllet/common/support/AuthorizationExtractorTest.kt
+++ b/src/test/kotlin/nexters/linkllet/common/support/AuthorizationExtractorTest.kt
@@ -10,6 +10,34 @@ import org.springframework.mock.web.MockHttpServletRequest
 class AuthorizationExtractorTest {
 
     @Test
+    @DisplayName("device-id를 추출한다")
+    fun extractValidDeviceId() {
+        // given
+        val request = MockHttpServletRequest()
+        val expected = "device_id"
+        request.addHeader("Device-Id", expected)
+
+        // when
+        val actual = DeviceHeaderExtractor.extractDeviceId(request)
+
+        // then
+        assertThat(actual).isEqualTo("device_id")
+    }
+
+    @Test
+    @DisplayName("device-id가 존재하지 않으면 빈 문자열을 반환한다")
+    fun extractNotExistDeviceId() {
+        // given
+        val request = MockHttpServletRequest()
+
+        // when
+        val actual = DeviceHeaderExtractor.extractDeviceId(request)
+
+        // then
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
     @DisplayName("이메일을 추출한다")
     fun extractValidEmail() {
         // given
@@ -25,7 +53,7 @@ class AuthorizationExtractorTest {
     }
 
     @Test
-    @DisplayName("토큰 형식이 Bearer로 시작하지 않으면 예외를 반환한다")
+    @DisplayName("토큰 형식이 Bearer로 시작하지 않으면 빈 문자열을 반환한다")
     fun extractValidBearerToken() {
         // given
         val request = MockHttpServletRequest()
@@ -33,8 +61,10 @@ class AuthorizationExtractorTest {
         request.addHeader("Authorization", expected)
 
         // when
+        val actual = AuthorizationExtractor.extractToken(request)
+
         // then
-        assertThrows<UnauthorizedException> { AuthorizationExtractor.extractToken(request) }
+        assertThat(actual).isEmpty()
     }
 
     @Test
@@ -51,13 +81,15 @@ class AuthorizationExtractorTest {
     }
 
     @Test
-    @DisplayName("토큰이 존재하지 않으면 예외를 반환한다")
+    @DisplayName("토큰이 존재하지 않으면 빈 문자열을 반환한다")
     fun extractNotExistToken() {
         // given
         val request = MockHttpServletRequest()
 
         // when
+        val actual = AuthorizationExtractor.extractToken(request)
+
         // then
-        assertThrows<UnauthorizedException> { AuthorizationExtractor.extractToken(request) }
+        assertThat(actual).isEmpty()
     }
 }

--- a/src/test/kotlin/nexters/linkllet/common/support/JwtProviderTest.kt
+++ b/src/test/kotlin/nexters/linkllet/common/support/JwtProviderTest.kt
@@ -43,7 +43,7 @@ class JwtProviderTest {
     @DisplayName("만료된 토큰에서 payload 추출 시 예외를 반환한다")
     fun getPayloadByExpiredToken() {
         // given
-        val jwtConfigProperties = JwtConfigProperties(VALID_SECRET_KEY, -1)
+        val jwtConfigProperties = JwtConfigProperties(VALID_SECRET_KEY, "-1")
         val expiredTokenProvider = JwtProvider(jwtConfigProperties)
 
         // when
@@ -54,6 +54,6 @@ class JwtProviderTest {
     companion object {
         private const val VALID_SECRET_KEY = "testtesttesttesttesttesttesttest"
         private const val INVALID_SECRET_KEY = "wrongtesttesttesttesttesttesttest"
-        private const val EXPIRATION_TIME: Long = 3600000
+        private const val EXPIRATION_TIME: String = "3600000"
     }
 }

--- a/src/test/kotlin/nexters/linkllet/domain/member/MemberTest.kt
+++ b/src/test/kotlin/nexters/linkllet/domain/member/MemberTest.kt
@@ -11,7 +11,7 @@ class MemberTest {
     @Test
     fun add_feedback() {
         // given
-        val member = Member(email = "shine@naver.com")
+        val member = Member("shine@naver.com")
 
         // when
         member.addFeedback("피드백1")

--- a/src/test/kotlin/nexters/linkllet/util/DatabaseLoader.kt
+++ b/src/test/kotlin/nexters/linkllet/util/DatabaseLoader.kt
@@ -24,7 +24,7 @@ class DatabaseLoader(
     fun loadData() {
         log.info("[call DataLoader]")
 
-        val newMember = memberRepository.save(Member(email = "kth990303@naver.com"))
+        val newMember = memberRepository.save(Member("kth990303@naver.com"))
         folderRepository.save(Folder(DEFAULT_FOLDER_NAME, newMember.getId, FolderType.DEFAULT))
 
         log.info("[init complete DataLoader]")


### PR DESCRIPTION
close: #49 

카카오 로그인 API를 제거하고 카카오 OAuth의 경우 기존 device_id 방식을 사용하도록 변경한다